### PR TITLE
fix for error when iterating over RDAP value types in the RDAP JSON v…

### DIFF
--- a/validator/src/main/java/org/icann/rdapconformance/validator/SchemaValidator.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/SchemaValidator.java
@@ -30,6 +30,7 @@ import org.icann.rdapconformance.validator.workflow.rdap.dataset.model.LinkRelat
 import org.icann.rdapconformance.validator.workflow.rdap.dataset.model.MediaTypes;
 import org.icann.rdapconformance.validator.workflow.rdap.dataset.model.NoticeAndRemarkJsonValues;
 import org.icann.rdapconformance.validator.workflow.rdap.dataset.model.RDAPExtensions;
+import org.icann.rdapconformance.validator.workflow.rdap.dataset.model.RedactedExpressionLanguageJsonValues;
 import org.icann.rdapconformance.validator.workflow.rdap.dataset.model.RoleJsonValues;
 import org.icann.rdapconformance.validator.workflow.rdap.dataset.model.SpecialIPv4Addresses;
 import org.icann.rdapconformance.validator.workflow.rdap.dataset.model.SpecialIPv6Addresses;
@@ -105,6 +106,8 @@ public class SchemaValidator {
             new DatasetValidator(ds.get(EventActionJsonValues.class), "eventAction"))
         .addFormatValidator(
             new DatasetValidator(ds.get(StatusJsonValues.class), "status"))
+        .addFormatValidator(
+            new DatasetValidator(ds.get(RedactedExpressionLanguageJsonValues.class), "redactedExpressionLanguage"))
         .addFormatValidator(
             new DatasetValidator(ds.get(VariantRelationJsonValues.class), "variantRelation"))
         .addFormatValidator(

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPDatasetService.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPDatasetService.java
@@ -24,6 +24,7 @@ import org.icann.rdapconformance.validator.workflow.rdap.dataset.model.EventActi
 import org.icann.rdapconformance.validator.workflow.rdap.dataset.model.NoticeAndRemarkJsonValues;
 import org.icann.rdapconformance.validator.workflow.rdap.dataset.model.RDAPDatasetModel;
 import org.icann.rdapconformance.validator.workflow.rdap.dataset.model.RDAPJsonValues;
+import org.icann.rdapconformance.validator.workflow.rdap.dataset.model.RedactedExpressionLanguageJsonValues;
 import org.icann.rdapconformance.validator.workflow.rdap.dataset.model.RegistrarId;
 import org.icann.rdapconformance.validator.workflow.rdap.dataset.model.RoleJsonValues;
 import org.icann.rdapconformance.validator.workflow.rdap.dataset.model.StatusJsonValues;
@@ -98,6 +99,9 @@ public class RDAPDatasetService {
 
     this.datasetValidatorModels.put(StatusJsonValues.class,
         new StatusJsonValues(get(RDAPJsonValues.class)));
+
+    this.datasetValidatorModels.put(RedactedExpressionLanguageJsonValues.class,
+        new RedactedExpressionLanguageJsonValues(get(RDAPJsonValues.class)));
 
     this.datasetValidatorModels.put(VariantRelationJsonValues.class,
         new VariantRelationJsonValues(get(RDAPJsonValues.class)));

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/dataset/model/RDAPJsonValues.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/dataset/model/RDAPJsonValues.java
@@ -45,7 +45,7 @@ public class RDAPJsonValues extends XmlObject {
     EVENT_ACTION,
     ROLE,
     DOMAIN_VARIANT_RELATION,
-
+    REDACTED_EXPRESSION_LANGUAGE,
   }
 
   private static class Record {

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/dataset/model/RedactedExpressionLanguageJsonValues.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/dataset/model/RedactedExpressionLanguageJsonValues.java
@@ -1,0 +1,10 @@
+package org.icann.rdapconformance.validator.workflow.rdap.dataset.model;
+
+import org.icann.rdapconformance.validator.workflow.rdap.dataset.model.RDAPJsonValues.JsonValueType;
+
+public class RedactedExpressionLanguageJsonValues extends RDAPSubJsonValues {
+
+  public RedactedExpressionLanguageJsonValues(RDAPJsonValues rdapJsonValues) {
+    super(rdapJsonValues, JsonValueType.REDACTED_EXPRESSION_LANGUAGE);
+  }
+}


### PR DESCRIPTION
This PR covers a fix where the conformance tool errors out when encountering the "redacted expression language" string in the RDAP JSON Values registry maintained by IANA. This fix DOES NOT cover usage of "redacted expression language" in RDAP responses.