### PR TITLE
Send accept header, false-positives config file and properly version the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ datasets
 jitpack/
 .classpath
 .java-version
+
+# stupid MacOS things
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,6 @@ results
 datasets
 .project
 .settings/
-jitpack/
 .classpath
 .java-version
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,6 @@ COPY . /app
 
 RUN mvn package -DskipTests --quiet
 
-RUN jo definitionIdentifier=test > config.json
-
 RUN mkdir datasets results
 
 ADD https://www.iana.org/assignments/rdap-extensions/rdap-extensions.xml datasets/rdap-extensions.xml

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -19,7 +19,7 @@ for arg in "$@" ; do
   fi
 done
 
-java -jar tool/target/rdapct-1.0.4.jar -c config.json --use-local-datasets "$@" 1>&2
+java -jar tool/target/rdapct-1.0.4.jar -c tool/bin/rdapct_config.json --use-local-datasets "$@" 1>&2
 
 
 

--- a/jitpack/pom.xml
+++ b/jitpack/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.icann</groupId>
     <artifactId>rdap-conformance</artifactId>
-    <version>1.0.4</version>
+    <version>${revision}</version>
   </parent>
   <groupId>org.icann.rdap-conformance</groupId>
   <artifactId>jitpack</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.icann</groupId>
     <artifactId>rdap-conformance</artifactId>
-    <version>1.0.4</version>
+    <version>${revision}</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -24,6 +24,9 @@
     </distributionManagement>
 
     <properties>
+        <!-- Use this to version the project! -->
+        <revision>1.0.5</revision>
+
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <org.aspectj-version>1.9.6</org.aspectj-version>

--- a/tool/bin/rdapct_config.json
+++ b/tool/bin/rdapct_config.json
@@ -1,0 +1,6 @@
+{
+    "definitionIdentifier": "Default RDAP Conformance Tool Configuration",
+    "definitionWarning": [],
+    "definitionIgnore": [ -46101, -10403, -10605, -10704, -12214, -12217, -12210, -12208, -12411, -12310, -11901 ],
+    "definitionNotes": ["This configuration removes tests that are known to be false positives."]
+}

--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.icann</groupId>
     <artifactId>rdap-conformance</artifactId>
-    <version>1.0.4</version>
+    <version>${revision}</version>
   </parent>
   <groupId>org.icann.rdap-conformance</groupId>
   <artifactId>tool</artifactId>
@@ -64,6 +64,12 @@
   </dependencies>
 
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>   
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/tool/src/main/java/org/icann/rdapconformance/tool/RdapConformanceTool.java
+++ b/tool/src/main/java/org/icann/rdapconformance/tool/RdapConformanceTool.java
@@ -18,8 +18,9 @@ import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
+import picocli.CommandLine.IVersionProvider;
 
-@Command(name = "rdap-conformance-tool", version = "1.0.0", mixinStandardHelpOptions = true)
+@Command(name = "rdap-conformance-tool", versionProvider = org.icann.rdapconformance.tool.VersionProvider.class, mixinStandardHelpOptions = true)
 public class RdapConformanceTool implements RDAPValidatorConfiguration, Callable<Integer> {
 
   @Parameters(paramLabel = "RDAP_URI", description = "The URI to be tested", index = "0")
@@ -153,3 +154,4 @@ public class RdapConformanceTool implements RDAPValidatorConfiguration, Callable
     private boolean thin = false;
   }
 }
+

--- a/tool/src/main/java/org/icann/rdapconformance/tool/VersionProvider.java
+++ b/tool/src/main/java/org/icann/rdapconformance/tool/VersionProvider.java
@@ -1,0 +1,15 @@
+package org.icann.rdapconformance.tool;
+
+import java.util.Properties;
+import picocli.CommandLine.IVersionProvider;
+
+public class VersionProvider implements IVersionProvider {
+  public VersionProvider() {
+  }
+
+  public String[] getVersion() throws Exception {
+    Properties properties = new Properties();
+    properties.load(this.getClass().getClassLoader().getResourceAsStream("version.properties"));
+    return new String[] { "${COMMAND-FULL-NAME} " + properties.getProperty("tool.version")};
+  }
+}

--- a/tool/src/main/resources/version.properties
+++ b/tool/src/main/resources/version.properties
@@ -1,0 +1,1 @@
+tool.version=${project.version}

--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.icann</groupId>
     <artifactId>rdap-conformance</artifactId>
-    <version>1.0.4</version>
+    <version>${revision}</version>
   </parent>
   <groupId>org.icann.rdap-conformance</groupId>
   <artifactId>validator</artifactId>

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpRequest.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpRequest.java
@@ -28,6 +28,7 @@ public class RDAPHttpRequest {
     HttpRequest.Builder httpRequestBuilder = HttpRequest.newBuilder()
         .uri(uri)
         .version(Version.HTTP_2)
+        .header("Accept", "application/rdap+json, application/json")
         .timeout(Duration.of(timeout, SECONDS));
     HttpRequest request;
     switch (method) {


### PR DESCRIPTION
This PR does the following:
1. it sets the accept header according to RFC 7480.
2. Uses a default config file that ignores the false positives.
3. Sets versioning to be in one place.