### PR TITLE
updating to Java 11 and updating dependencies and security issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK 21
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: 21
 
     - name: Build project with Maven
       run: mvn -B package --file pom.xml

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ datasets
 .settings/
 .classpath
 .java-version
+.flattened-pom.xml
 
 # stupid MacOS things
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY . /app
 
 RUN mvn package -DskipTests --quiet
 
-RUN mkdir datasets results
+RUN mkdir -p datasets results
 
 ADD https://www.iana.org/assignments/rdap-extensions/rdap-extensions.xml datasets/rdap-extensions.xml
 ADD https://www.iana.org/assignments/registrar-ids/registrar-ids.xml datasets/registrar-ids.xml

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,10 +19,10 @@ node('docker') {
         stage ('Run Tests'){
 
             if( "${env.BRANCH_NAME}" == 'master'){
-                utils.mvn(args: 'clean deploy', jdkVersion: 'jdk11', publishArtifacts: true)
+                utils.mvn(args: 'clean deploy', jdkVersion: 'jdk21', publishArtifacts: true)
             }
             else{
-                utils.mvn(args: 'clean test', jdkVersion: 'jdk11')
+                utils.mvn(args: 'clean test', jdkVersion: 'jdk21')
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ This is a maven project: to build the executable jar simply run
 
 # Requirements
 
-- Java 11
+- Java 21
 
 # Internals
 

--- a/jitpack/pom.xml
+++ b/jitpack/pom.xml
@@ -36,8 +36,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <source>11</source>
-          <target>11</target>
+          <source>21</source>
+          <target>21</target>
           <compilerArgs>
             <arg>-Aproject=${project.groupId}/${project.artifactId}</arg>
           </compilerArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -25,26 +25,28 @@
 
     <properties>
         <!-- Use this to version the project! -->
-        <rdap-conformance.version>1.0.5</rdap-conformance.version>
+        <rdap-conformance.version>1.0.6</rdap-conformance.version>
+        <!-- -->
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <org.aspectj-version>1.9.6</org.aspectj-version>
 
-        <maven.compiler.target>11</maven.compiler.target>
-        <maven.compiler.source>11</maven.compiler.source>
-        <jackson-databind.version>2.12.7.1</jackson-databind.version>
+        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <jackson-databind.version>2.18.1</jackson-databind.version>
         <slf4j-api.version>1.7.30</slf4j-api.version>
         <ipaddress.version>5.0.0</ipaddress.version>
         <icu4j.version>69.1</icu4j.version>
-        <json-path.version>2.4.0</json-path.version>
-        <dnsjava.version>3.3.1</dnsjava.version>
+        <json-path.version>2.9.0</json-path.version>
+        <json-smart.version>2.5.0</json-smart.version>
+        <dnsjava.version>3.6.2</dnsjava.version>
         <commons-text.version>1.10.0</commons-text.version>
         <testng.version>7.9.0</testng.version>
         <assertj-core.version>3.19.0</assertj-core.version>
         <mockito-testng.version>0.5.2</mockito-testng.version>
         <slf4j-simple.version>1.7.30</slf4j-simple.version>
-        <wiremock.version>3.0.1</wiremock.version>
+        <wiremock.version>3.0.3</wiremock.version>
         <jaxb-impl.version>4.0.5</jaxb-impl.version>
         <jaxb.version>4.0.1</jaxb.version>
         <javassist.version>3.25.0-GA</javassist.version>
@@ -101,6 +103,12 @@
                 <groupId>com.jayway.jsonpath</groupId>
                 <artifactId>json-path</artifactId>
                 <version>${json-path.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>net.minidev</groupId>
+                <artifactId>json-smart</artifactId>
+                <version>${json-smart.version}</version>
             </dependency>
 
             <dependency>
@@ -186,6 +194,33 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>3.2.5</version>
+            </plugin>
+            <!-- This is needed to resolve rdapct with maven install locally.
+                 such as incorporating the validator in other Java programs.  -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.1.0</version>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                </configuration>
+                <executions>
+                    <execution>
+                    <id>flatten</id>
+                    <phase>process-resources</phase>
+                    <goals>
+                        <goal>flatten</goal>
+                    </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/tool/README.md
+++ b/tool/README.md
@@ -48,8 +48,9 @@ Usage: rdap-conformance-tool [-hV] [--use-local-datasets]
 | RDAP Response Profile - Entities within Domain - Registry        |                      | x              |                  |                              |                  |                 |                  |                 |                  |                    |                  |
 | RDAP Response Profile - Entities within Domain - Registrar       |                      |                | x                |                              |                  |                 |                  |                 |                  |                    |                  |
 | RDAP Response Profile - Entity - Registrar                       |                      |                |                  |                              |                  | x               |                  |                 |                  |                    |                  |
+
 # Requirements
-- Java 11
+- Java 21
 
 # Acknowledgements
 This RDAP conformance tool has been developed by Viagénie

--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -16,8 +16,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <maven.compiler.target>11</maven.compiler.target>
-    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
+    <maven.compiler.source>21</maven.compiler.source>
   </properties>
 
   <dependencies>
@@ -76,8 +76,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <source>11</source>
-          <target>11</target>
+          <source>21</source>
+          <target>21</target>
           <annotationProcessorPaths>
             <path>
               <groupId>info.picocli</groupId>
@@ -118,6 +118,17 @@
         </executions>
         <configuration>
           <finalName>rdapct-${project.version}</finalName>
+          <!-- This is needed to because DNS Java is now multi-release or something something...
+               https://github.com/dnsjava/dnsjava/issues/338                                    -->
+          <transformers>
+            <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+              <mainClass>org.icann.rdapconformance.tool.Main</mainClass>
+                <manifestEntries>
+                  <Multi-Release>true</Multi-Release>
+                </manifestEntries>
+              </transformer>
+            <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+          </transformers>
         </configuration>
       </plugin>
     </plugins>

--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -14,6 +14,13 @@
   <packaging>jar</packaging>
   <name>rdap-conformance-validator</name>
 
+    <properties>
+        <!-- This allows tests to work under Java 21. Bytebuddy is a dependency
+             of mockito, and long story short... updates aren't yet available
+             for mockito to use the correct version of ByteBuddy yet.           -->
+        <argLine>-Dnet.bytebuddy.experimental=true</argLine>
+    </properties>
+
     <dependencies>
 
         <dependency>
@@ -69,6 +76,11 @@
         </dependency>
 
         <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>dnsjava</groupId>
             <artifactId>dnsjava</artifactId>
         </dependency>
@@ -118,8 +130,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>21</source>
+                    <target>21</target>
                     <compilerArgs>
                         <arg>-Aproject=${project.groupId}/${project.artifactId}</arg>
                     </compilerArgs>


### PR DESCRIPTION
This PR updates the project to use Java 21 and updates the dependencies that are security issues.

**NOTE** This fails to build on the master branch because the master branch is using Java 11. However the code in the master branch fails to build on Java 21 and the fix for that is in this PR. Therefore, this PR has to be merged into master before the build in master will succeed. We will force a build from master before releasing.