### PR TITLE
updates the tests to be ignored and bumps the version number to 1.0.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <properties>
         <!-- Use this to version the project! -->
-        <rdap-conformance.version>1.0.6</rdap-conformance.version>
+        <rdap-conformance.version>1.0.7</rdap-conformance.version>
         <!-- -->
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/tool/bin/rdapct_config.json
+++ b/tool/bin/rdapct_config.json
@@ -1,6 +1,14 @@
 {
-    "definitionIdentifier": "Default RDAP Conformance Tool Configuration",
-    "definitionWarning": [],
-    "definitionIgnore": [ -46101, -10403, -10605, -10704, -12214, -12217, -12210, -12208, -12411, -12310, -11901 ],
-    "definitionNotes": ["This configuration removes tests that are known to be false positives."]
+  "definitionIdentifier": "Default RDAP Conformance Tool Configuration",
+  "definitionWarning": [],
+  "definitionIgnore": [
+    -46101,
+    -10403,
+    -52104,
+    -47000,
+    -47203
+  ],
+  "definitionNotes": [
+    "This configuration removes tests that are known to be false positives."
+  ]
 }


### PR DESCRIPTION
The PR updates the ignores list by removing the media type related tests from the list and adding new tests that need to be ignored for now.

It also bumps the version number to 1.0.7.