### PR TITLE
bug/RCT-40-invalid-u-label

### DIFF
--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/QueryValidation.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/QueryValidation.java
@@ -50,7 +50,9 @@ public abstract class QueryValidation extends ProfileJsonValidation {
       logger.error("Invalid domain name");
       return false;
     }
-    if (ldhNameBuilder.toString().equals(domainName)) {
+
+    // Using equalsIgnoreCase based on nameToASCII method returns in lowercase domain name
+    if (ldhNameBuilder.toString().equalsIgnoreCase(domainName)) {
       // URI contains only A-label or NR-LDH labels
       if (NULL.equals(jsonObject.opt("ldhName"))) {
         results.add(RDAPValidationResult.builder()


### PR DESCRIPTION
CHANGE: validation modified to use equalsIgnoreCase based on nameToASCII function returns lower case in domain names avoiding false positives