### PR TITLE
52104 should not be applied to any entities that are the children of registrar

### DIFF
--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/entities/EntitiesWithinDomainProfileJsonValidation.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/entities/EntitiesWithinDomainProfileJsonValidation.java
@@ -1,13 +1,10 @@
 package org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain.entities;
 
-import java.util.HashSet;
 import java.util.Set;
 import org.icann.rdapconformance.validator.configuration.RDAPValidatorConfiguration;
 import org.icann.rdapconformance.validator.workflow.profile.ProfileJsonValidation;
 import org.icann.rdapconformance.validator.workflow.rdap.RDAPQueryType;
-import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidationResult;
 import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidatorResults;
-import org.json.JSONArray;
 import org.json.JSONObject;
 
 public abstract class EntitiesWithinDomainProfileJsonValidation extends ProfileJsonValidation {
@@ -35,23 +32,9 @@ public abstract class EntitiesWithinDomainProfileJsonValidation extends ProfileJ
         + ")]");
 
     boolean isValid = true;
-    Set<String> roles = new HashSet<>();
     for (String jsonPointer : entityJsonPointers) {
       JSONObject entity = (JSONObject) jsonObject.query(jsonPointer);
 
-      if (entity.has("roles")) {
-        for (Object role : entity.getJSONArray("roles")) {
-          if (!roles.add(role.toString())) {
-            results.add(RDAPValidationResult.builder()
-                .code(-52104)
-                .value(getResultValue(jsonPointer))
-                .message("More than one entity with the following roles were found: "
-                    + "registrant, administrative, technical and billing.")
-                .build());
-            isValid = false;
-          }
-        }
-      }
 
       isValid &= doValidateEntity(jsonPointer, entity);
     }

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/entities/ResponseValidation2Dot7Dot1DotXAndRelated5.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/entities/ResponseValidation2Dot7Dot1DotXAndRelated5.java
@@ -1,0 +1,84 @@
+package org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain.entities;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.commons.lang3.StringUtils;
+import org.icann.rdapconformance.validator.configuration.RDAPValidatorConfiguration;
+import org.icann.rdapconformance.validator.workflow.rdap.RDAPQueryType;
+import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidationResult;
+import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidatorResults;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 8.8.1.5
+ */
+public class ResponseValidation2Dot7Dot1DotXAndRelated5 extends
+    ResponseValidation2Dot7Dot1DotXAndRelated {
+    private static final Logger logger = LoggerFactory.getLogger(ResponseValidation2Dot7Dot1DotXAndRelated5.class);
+
+    private final Set<String> roles = new HashSet<>();
+
+    public ResponseValidation2Dot7Dot1DotXAndRelated5(String rdapResponse,
+        RDAPValidatorResults results,
+        RDAPQueryType queryType,
+        RDAPValidatorConfiguration config) {
+        super(rdapResponse, results, queryType, config);
+    }
+
+    @Override
+    protected boolean doValidateEntity(String jsonPointer, JSONObject entity) {
+        // the parent class EntitiesWithinDomainProfileJsonValidation.doValidate() passes all "entity"
+        // in the json of those 4 roles, regardless of "level".
+        // need to exclude those are the children of "registrar" role
+        // https://icann-jira.atlassian.net/browse/RCT-88
+        if (isChildOfRegistrar(jsonPointer)) {
+            return true;
+        }
+
+        boolean isValid = true;
+        if (entity.has("roles")) {
+            for (Object role : entity.getJSONArray("roles")) {
+                if (!roles.add(role.toString())) {
+                    results.add(RDAPValidationResult.builder()
+                        .code(-52104)
+                        .value(getResultValue(jsonPointer))
+                        .message("More than one entity with the following roles were found: "
+                            + "registrant, administrative, technical and billing.")
+                        .build());
+                    isValid = false;
+                }
+            }
+        }
+
+        return isValid;
+    }
+
+    private boolean isChildOfRegistrar(String jsonPointer) {
+        int level = StringUtils.countMatches(jsonPointer, "entities");
+
+        if (level == 1) {
+            jsonPointer = jsonPointer + "/roles";
+
+            JSONArray roles = (JSONArray) jsonObject.query(jsonPointer);
+
+            for (Object role : roles) {
+                if ("registrar".equalsIgnoreCase(role.toString())) {
+                    return true;
+                }
+            }
+        } else if (level > 1) {
+            // it is child
+            jsonPointer = jsonPointer.substring(0, jsonPointer.lastIndexOf("entities") - 1);
+
+            return isChildOfRegistrar(jsonPointer);
+        } else {
+            //level < 1, i.e. "entities" is not found in the jsonPointer, should never happen
+            logger.warn("level = {}, jsonPointer = {}", level, jsonPointer);
+        }
+
+        return false;
+    }
+}

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidator.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidator.java
@@ -31,6 +31,7 @@ import org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain
 import org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain.entities.ResponseValidation2Dot7Dot1DotXAndRelated1;
 import org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain.entities.ResponseValidation2Dot7Dot1DotXAndRelated2;
 import org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain.entities.ResponseValidation2Dot7Dot1DotXAndRelated3And4;
+import org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain.entities.ResponseValidation2Dot7Dot1DotXAndRelated5;
 import org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain.entities.ResponseValidation2Dot7Dot1DotXAndRelated6;
 import org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain.entities.ResponseValidation2Dot7Dot5Dot2;
 import org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain.entities.ResponseValidation2Dot7Dot5Dot3;
@@ -246,6 +247,8 @@ public class RDAPValidator implements ValidatorWorkflow {
                   queryTypeProcessor.getQueryType(), config,
                   new SimpleHandleValidation(query.getData(), results, datasetService,
                       queryTypeProcessor.getQueryType(), -52102)),
+              new ResponseValidation2Dot7Dot1DotXAndRelated5(query.getData(), results,
+                  queryTypeProcessor.getQueryType(), config),
               new ResponseValidation2Dot7Dot1DotXAndRelated6(query.getData(), results,
                   queryTypeProcessor.getQueryType(), config),
               new ResponseValidation2Dot7Dot5Dot2(query.getData(), results,

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/entities/ResponseValidation2Dot7Dot1DotXAndRelated5Test.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/entities/ResponseValidation2Dot7Dot1DotXAndRelated5Test.java
@@ -1,0 +1,48 @@
+package org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain.entities;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.icann.rdapconformance.validator.workflow.profile.ProfileValidation;
+import org.testng.annotations.Test;
+
+public class ResponseValidation2Dot7Dot1DotXAndRelated5Test extends
+    ResponseValidation2Dot7Dot1DotXAndRelatedTest {
+
+  /**
+   * 8.8.1.5
+   */
+  @Test
+  public void moreThanOneEntityWithRegistrantRole() {
+    entitiesWithRole("registrant");
+    // add again the registrant
+    jsonObject.getJSONArray("entities").put(jsonObject.getJSONArray("entities").getJSONObject(0));
+    // verify we have two entity with registrant role:
+    assertThat((List<String>) getValue("$.entities[*].roles[?(@ == 'registrant')]")).hasSize(2);
+
+    String registrant = "#/entities/0:" + jsonObject.query("#/entities/0");
+    validate(-52104, registrant, "More than one entity with the following roles were found: "
+        + "registrant, administrative, technical and billing.");
+  }
+
+  /**
+   * 8.8.1.5
+   */
+  @Test
+  public void moreThanOneEntityWithDifferentRoles() {
+    entitiesWithRole("registrant");
+    // add another role:
+    jsonObject.getJSONArray("entities").put(jsonObject.getJSONArray("entities").getJSONObject(0));
+    replaceValue("$['entities'][1]['roles'][0]", "administrative");
+    // verify we have two entity with different roles:
+    assertThat((List<String>) getValue("$.entities[*].roles[?(@ == 'registrant' || @ == 'administrative')]")).hasSize(2);
+
+    validate();
+  }
+
+  @Override
+  public ProfileValidation getProfileValidation() {
+    return new ResponseValidation2Dot7Dot1DotXAndRelated5(jsonObject.toString(), results,
+        queryType, config);
+  }
+}

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/entities/ResponseValidation2Dot7Dot1DotXAndRelatedTest.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/entities/ResponseValidation2Dot7Dot1DotXAndRelatedTest.java
@@ -10,7 +10,6 @@ import org.icann.rdapconformance.validator.configuration.RDAPValidatorConfigurat
 import org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain.ResponseDomainValidationTestBase;
 import org.icann.rdapconformance.validator.workflow.rdap.RDAPQueryType;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
 
 public abstract class ResponseValidation2Dot7Dot1DotXAndRelatedTest extends
     ResponseDomainValidationTestBase {
@@ -27,37 +26,6 @@ public abstract class ResponseValidation2Dot7Dot1DotXAndRelatedTest extends
     super.setUp();
     config = mock(RDAPValidatorConfiguration.class);
     doReturn(true).when(config).isGtldRegistrar();
-  }
-
-  /**
-   * 8.8.1.5
-   */
-  @Test
-  public void moreThanOneEntityWithRegistrantRole() {
-    entitiesWithRole("registrant");
-    // add again the registrant
-    jsonObject.getJSONArray("entities").put(jsonObject.getJSONArray("entities").getJSONObject(0));
-    // verify we have two entity with registrant role:
-    assertThat((List<String>) getValue("$.entities[*].roles[?(@ == 'registrant')]")).hasSize(2);
-
-    String registrant = "#/entities/0:" + jsonObject.query("#/entities/0");
-    validate(-52104, registrant, "More than one entity with the following roles were found: "
-        + "registrant, administrative, technical and billing.");
-  }
-
-  /**
-   * 8.8.1.5
-   */
-  @Test
-  public void moreThanOneEntityWithDifferentRoles() {
-    entitiesWithRole("registrant");
-    // add another role:
-    jsonObject.getJSONArray("entities").put(jsonObject.getJSONArray("entities").getJSONObject(0));
-    replaceValue("$['entities'][1]['roles'][0]", "administrative");
-    // verify we have two entity with different roles:
-    assertThat((List<String>) getValue("$.entities[*].roles[?(@ == 'registrant' || @ == 'administrative')]")).hasSize(2);
-
-    validate();
   }
 
   protected void remarkMemberIs(String key, String value) {


### PR DESCRIPTION
1. in the existing code, the validation of 52104 (section 2.7.1.5) is in the parent abstract class EntitiesWithinDomainProfileJsonValidation. Which is not correct and will be unnecessarily run multiple times
2. created a dedicated class ResponseValidaton2Dot7Dot1DotXandRelated5 for the check and added the logic to exclude entities that is the child or grandchild of registrar

https://icann-jira.atlassian.net/browse/RCT-88