### PR TITLE
feature/RCT-29-command-profile-2024

### DIFF
--- a/tool/src/main/java/org/icann/rdapconformance/tool/RdapConformanceTool.java
+++ b/tool/src/main/java/org/icann/rdapconformance/tool/RdapConformanceTool.java
@@ -92,22 +92,25 @@ public class RdapConformanceTool implements RDAPValidatorConfiguration, Callable
 
   @Override
   public boolean useRdapProfileFeb2019() {
-    return this.dependantRdapProfileGtld.useRdapProfileFeb2019;
-  }
+    return this.dependantRdapProfileGtld.exclusiveRdapProfile.dependantRdapProfile.useRdapProfileFeb2019;}
+
+  @Override
+  public boolean useRdapProfileFeb2024() { return this.dependantRdapProfileGtld.exclusiveRdapProfile.dependantRdapProfile.useRdapProfileFeb2024; }
+
 
   @Override
   public boolean isGtldRegistrar() {
-    return this.dependantRdapProfileGtld.exclusiveGtldType.gtldRegistrar;
+    return this.dependantRdapProfileGtld.exclusiveRdapProfile.exclusiveGtldType.gtldRegistrar;
   }
 
   @Override
   public boolean isGtldRegistry() {
-    return this.dependantRdapProfileGtld.exclusiveGtldType.dependantRegistryThin.gtldRegistry;
+    return this.dependantRdapProfileGtld.exclusiveRdapProfile.exclusiveGtldType.dependantRegistryThin.gtldRegistry;
   }
 
   @Override
   public boolean isThin() {
-    return this.dependantRdapProfileGtld.exclusiveGtldType.dependantRegistryThin.thin;
+    return this.dependantRdapProfileGtld.exclusiveRdapProfile.exclusiveGtldType.dependantRegistryThin.thin;
   }
 
   @Override
@@ -126,12 +129,27 @@ public class RdapConformanceTool implements RDAPValidatorConfiguration, Callable
   }
 
   private static class DependantRdapProfileGtld {
+    @ArgGroup(multiplicity = "1", exclusive = false)
+    ExclusiveRdapProfile exclusiveRdapProfile = new ExclusiveRdapProfile();
+  }
 
-    @Option(names = {"--use-rdap-profile-february-2019"},
-        description = "Use RDAP Profile February 2019", defaultValue = "false")
-    boolean useRdapProfileFeb2019 = false;
+  private static class ExclusiveRdapProfile {
+
+    @ArgGroup()
+    private DependantRdapProfile dependantRdapProfile = new DependantRdapProfile();
+
     @ArgGroup(multiplicity = "1")
     ExclusiveGtldType exclusiveGtldType = new ExclusiveGtldType();
+
+  }
+
+  private static class DependantRdapProfile {
+    @Option(names = {"--use-rdap-profile-february-2019"},
+            description = "Use RDAP Profile February 2019", defaultValue = "false")
+    boolean useRdapProfileFeb2019 = false;
+    @Option(names = {"--use-rdap-profile-february-2024"},
+            description = "Use RDAP Profile February 2024", required = true)
+    private boolean useRdapProfileFeb2024 = false;
   }
 
   private static class ExclusiveGtldType {

--- a/tool/src/test/java/org/icann/rdapconformance/tool/RdapConformanceToolArgsTest.java
+++ b/tool/src/test/java/org/icann/rdapconformance/tool/RdapConformanceToolArgsTest.java
@@ -81,7 +81,7 @@ public class RdapConformanceToolArgsTest {
 
   @Test
   public void testThinArg_WithGtldRegistry_IsOk() {
-    String[] args = "--config=/tmp/test --thin --gtld-registry http://example.org".split(" ");
+    String[] args = "--config=/tmp/test --thin --gtld-registry http://example.org --use-rdap-profile-february-2019".split(" ");
 
     assertThatCode(() -> new CommandLine(new RdapConformanceTool()).parseArgs(args))
         .doesNotThrowAnyException();
@@ -101,5 +101,22 @@ public class RdapConformanceToolArgsTest {
 
     assertThatCode(() -> new CommandLine(new RdapConformanceTool()).parseArgs(args))
         .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void testUseProfile2024Arg_IsBadMissingRegistrar() {
+    String[] args = "--config=/tmp/test --use-rdap-profile-february-2024 http://example.org".split(" ");
+
+    assertThatExceptionOfType(MissingParameterException.class).isThrownBy(
+                    () -> new CommandLine(new RdapConformanceTool()).parseArgs(args))
+            .withMessage("Error: Missing required argument(s): ([--gtld-registrar] | [--gtld-registry [--thin]])");
+  }
+
+  @Test
+  public void testUseProfile2024Arg_IsOk() {
+    String[] args = "--config=/tmp/test --gtld-registrar --use-rdap-profile-february-2024 http://example.org".split(" ");
+
+    assertThatCode(() -> new CommandLine(new RdapConformanceTool()).parseArgs(args))
+            .doesNotThrowAnyException();
   }
 }

--- a/validator/src/main/java/org/icann/rdapconformance/validator/configuration/RDAPValidatorConfiguration.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/configuration/RDAPValidatorConfiguration.java
@@ -24,6 +24,7 @@ public interface RDAPValidatorConfiguration {
   boolean useLocalDatasets();
 
   boolean useRdapProfileFeb2019();
+  boolean useRdapProfileFeb2024();
 
   boolean isGtldRegistrar();
 

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidator.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidator.java
@@ -271,6 +271,11 @@ public class RDAPValidator implements ValidatorWorkflow {
       rdapProfileFebruary2019.validate();
     }
 
+    if (config.useRdapProfileFeb2024()) {
+      logger.info("Validations for 2024 profile");
+    }
+
+
     query.getStatusCode().ifPresent(rdapValidationResultFile::build);
 
     this.resultsPath = rdapValidationResultFile.resultPath;


### PR DESCRIPTION
CHANGE: Command line parameter “--use-rdap-profile-february-2024” indicates the tests for the  ICANN gTLD RDAP Profile of February 2024 are included in the suite of queries.