### PR TITLE
bug/RCT-106-107: system should stop validation after writing the error 13001 and 13002 to the result file and exit with code 0.

### DIFF
--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidationStatus.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidationStatus.java
@@ -9,10 +9,6 @@ public enum RDAPValidationStatus {
   UNSUPPORTED_QUERY(3, "The RDAP query is not supported by the tool."),
   MIXED_LABEL_FORMAT(4, "The RDAP query is domain/<domain name> or nameserver/<nameserver>, "
       + "but A-labels and U-labels are mixed."),
-  EXPECTED_OBJECT_NOT_FOUND(8, "A response was available to the tool, the Content-Type is "
-      + "application/rdap+JSON in the response, the HTTP Status is 200 or 404, but the expected "
-      + "objectClassName in the topmost object was not found for a lookup query or the JSON "
-      + "array for a search query was not found a search query."),
   USES_THIN_MODEL(9, "The RDAP query is invalid because the TLD uses the thin model."),
   CONNECTION_FAILED(10, "Failed to connect to host."),
   HANDSHAKE_FAILED(11, "The TLS handshake failed."),

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidator.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidator.java
@@ -141,12 +141,18 @@ public class RDAPValidator implements ValidatorWorkflow {
     query.setResults(results);
     if (!query.run()) {
       query.getStatusCode().ifPresent(rdapValidationResultFile::build);
+
+      if (query.getErrorStatus() == null) {
+        // it means it is 13001 or 13002, the status will be null and we should exit with code 0
+        return RDAPValidationStatus.SUCCESS.getValue();
+      }
+
       return query.getErrorStatus().getValue();
     }
 
     if (!query.checkWithQueryType(queryTypeProcessor.getQueryType())) {
       query.getStatusCode().ifPresent(rdapValidationResultFile::build);
-      return RDAPValidationStatus.EXPECTED_OBJECT_NOT_FOUND.getValue();
+      return query.getErrorStatus().getValue();
     }
 
     SchemaValidator validator = null;

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import com.sun.net.httpserver.Headers;
 import org.icann.rdapconformance.validator.configuration.RDAPValidatorConfiguration;
 import org.icann.rdapconformance.validator.workflow.rdap.*;
 import org.slf4j.Logger;

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
@@ -28,6 +28,7 @@ public class RDAPHttpQuery implements RDAPQuery {
   private HttpResponse<String> httpResponse = null;
   private RDAPValidationStatus status = null;
   private JsonData jsonResponse = null;
+  private boolean isQuerySuccessful = true;
 
 
   public RDAPHttpQuery(RDAPValidatorConfiguration config) {
@@ -75,10 +76,6 @@ public class RDAPHttpQuery implements RDAPQuery {
      * not validation on the contents) for a search query, code error -13003 added in results file.
      */
     if (httpResponse.statusCode() == 200) {
-      if(!jsonResponse.isValid()) {
-        logger.error("The response was not valid JSON");
-        return false;
-      }
       if (queryType.isLookupQuery() && !jsonResponseValid()) {
         logger.error("objectClassName was not found in the topmost object");
         results.add(RDAPValidationResult.builder()
@@ -122,7 +119,7 @@ public class RDAPHttpQuery implements RDAPQuery {
    * Check if we got errors with the RDAP HTTP request.
    */
   private boolean isQuerySuccessful() {
-    return status == null;
+    return status == null && isQuerySuccessful;
   }
 
 
@@ -205,6 +202,9 @@ public class RDAPHttpQuery implements RDAPQuery {
                       .value("response body not given")
                       .message("The response was not valid JSON.")
                       .build());
+
+      isQuerySuccessful = false;
+      return;
     }
 
     /* If a response is available to the tool, but the HTTP status code is not 200 nor 404, error
@@ -217,6 +217,8 @@ public class RDAPHttpQuery implements RDAPQuery {
           .value(String.valueOf(httpStatusCode))
           .message("The HTTP status code was neither 200 nor 404.")
           .build());
+
+      isQuerySuccessful = false;
     }
   }
 

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidatorTest.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidatorTest.java
@@ -93,9 +93,9 @@ public class RDAPValidatorTest {
   public void testValidate_QuerycheckWithQueryTypeError_ReturnsError() {
     doReturn(RDAPQueryType.DOMAIN).when(processor).getQueryType();
     doReturn(false).when(query).checkWithQueryType(RDAPQueryType.DOMAIN);
-    doReturn(RDAPValidationStatus.EXPECTED_OBJECT_NOT_FOUND).when(query).getErrorStatus();
+    doReturn(RDAPValidationStatus.SUCCESS).when(query).getErrorStatus();
 
     assertThat(validator.validate())
-        .isEqualTo(RDAPValidationStatus.EXPECTED_OBJECT_NOT_FOUND.getValue());
+        .isEqualTo(RDAPValidationStatus.SUCCESS.getValue());
   }
 }

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQueryTest.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQueryTest.java
@@ -258,7 +258,7 @@ public class RDAPHttpQueryTest extends HttpTestingUtils {
             .withHeader("Content-Type", "application/rdap+JSON;encoding=UTF-8")
             .withBody(response)));
 
-    assertThat(rdapHttpQuery.run()).isTrue();
+    assertThat(rdapHttpQuery.run()).isFalse();
     assertThat(results.getAll()).contains(
             RDAPValidationResult.builder()
                     .code(-13001)
@@ -276,7 +276,7 @@ public class RDAPHttpQueryTest extends HttpTestingUtils {
         .withScheme("http")
         .willReturn(aResponse().withStatus(403)));
 
-    assertThat(rdapHttpQuery.run()).isTrue();
+    assertThat(rdapHttpQuery.run()).isFalse();
     assertThat(results.getAll()).contains(
         RDAPValidationResult.builder()
             .code(-13002)


### PR DESCRIPTION
1. reverted 5899153f
2. added isQuerySuccessful flag to RDAPHttpQuery class and set it to false to stop further validation for 13001 and 13002

https://icann-jira.atlassian.net/browse/RCT-106
https://icann-jira.atlassian.net/browse/RCT-107