### PR TITLE
Fix/rct-118-cli-output-params

### DIFF
--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidationStatus.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidationStatus.java
@@ -42,4 +42,13 @@ public enum RDAPValidationStatus {
   public String getDescription() {
     return description;
   }
+
+  public static RDAPValidationStatus fromValue(int value) {
+    for (RDAPValidationStatus status : values()) {
+      if (status.value == value) {
+        return status;
+      }
+    }
+    throw new IllegalArgumentException("Unknown value: " + value);
+  }
 }

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidator.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidator.java
@@ -3,6 +3,7 @@ package org.icann.rdapconformance.validator.workflow.rdap;
 import java.io.InputStream;
 import java.net.http.HttpResponse;
 import java.util.List;
+import java.util.Map;
 
 import org.icann.rdapconformance.validator.SchemaValidator;
 import org.icann.rdapconformance.validator.configuration.ConfigurationFile;
@@ -12,6 +13,7 @@ import org.icann.rdapconformance.validator.configuration.RDAPValidatorConfigurat
 import org.icann.rdapconformance.validator.workflow.DomainCaseFoldingValidation;
 import org.icann.rdapconformance.validator.workflow.FileSystem;
 import org.icann.rdapconformance.validator.workflow.ValidatorWorkflow;
+import org.icann.rdapconformance.validator.workflow.profile.ProfileValidation;
 import org.icann.rdapconformance.validator.workflow.profile.RDAPProfile;
 import org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain.ResponseValidation2Dot1;
 import org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain.ResponseValidation2Dot10;
@@ -60,242 +62,226 @@ import org.icann.rdapconformance.validator.workflow.profile.tig_section.registra
 import org.icann.rdapconformance.validator.workflow.profile.tig_section.registry.TigValidation1Dot11Dot1;
 import org.icann.rdapconformance.validator.workflow.profile.tig_section.registry.TigValidation3Dot2;
 import org.icann.rdapconformance.validator.workflow.profile.tig_section.registry.TigValidation6Dot1;
+import org.icann.rdapconformance.validator.workflow.rdap.http.RDAPHttpQuery;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class RDAPValidator implements ValidatorWorkflow {
 
-  private static final Logger logger = LoggerFactory.getLogger(RDAPValidator.class);
+    private static final Logger logger = LoggerFactory.getLogger(RDAPValidator.class);
 
-  private final RDAPValidatorConfiguration config;
-  private final RDAPQueryTypeProcessor queryTypeProcessor;
-  private final RDAPQuery query;
-  private final FileSystem fileSystem;
-  private final ConfigurationFileParser configParser;
-  private final RDAPValidatorResults results;
-  private final RDAPDatasetService datasetService;
+    private final RDAPValidatorConfiguration config;
+    private final RDAPQueryTypeProcessor queryTypeProcessor;
+    private final RDAPQuery query;
+    private final FileSystem fileSystem;
+    private final ConfigurationFileParser configParser;
+    private final RDAPValidatorResults results;
+    private final RDAPDatasetService datasetService;
 
-  private String resultsPath;
+    private String resultsPath;
 
-  public RDAPValidator(RDAPValidatorConfiguration config,
-      FileSystem fileSystem,
-      RDAPQueryTypeProcessor queryTypeProcessor,
-      RDAPQuery query) {
-    this(config, fileSystem, queryTypeProcessor, query,
-        new ConfigurationFileParserImpl(),
-        new RDAPValidatorResultsImpl(),
-        new RDAPDatasetServiceImpl(fileSystem));
-  }
-
-  public RDAPValidator(RDAPValidatorConfiguration config,
-      FileSystem fileSystem,
-      RDAPQueryTypeProcessor queryTypeProcessor,
-      RDAPQuery query,
-      ConfigurationFileParser configParser,
-      RDAPValidatorResults results,
-      RDAPDatasetService datasetService) {
-    this.config = config;
-    this.fileSystem = fileSystem;
-    this.query = query;
-    if (!this.config.check()) {
-      logger.error("Please fix the configuration");
-      throw new RuntimeException("Please fix the configuration");
-    }
-    this.queryTypeProcessor = queryTypeProcessor;
-    this.configParser = configParser;
-    this.results = results;
-    this.datasetService = datasetService;
-  }
-
-  @Override
-  public int validate() {
-    /*
-     * Parse the configuration definition file, and if the file is not parsable,
-     * exit with a return code of 1.
-     */
-    ConfigurationFile configurationFile;
-    try (InputStream is = fileSystem.uriToStream(this.config.getConfigurationFile())) {
-      configurationFile = configParser.parse(is);
-    } catch (Exception e) {
-      logger.error("Configuration is invalid", e);
-      return RDAPValidationStatus.CONFIG_INVALID.getValue();
+    public RDAPValidator(RDAPValidatorConfiguration config,
+                         FileSystem fileSystem,
+                         RDAPQueryTypeProcessor queryTypeProcessor,
+                         RDAPQuery query) {
+        this(config, fileSystem, queryTypeProcessor, query, new ConfigurationFileParserImpl(),
+            new RDAPValidatorResultsImpl(), new RDAPDatasetServiceImpl(fileSystem));
     }
 
-    final RDAPValidationResultFile rdapValidationResultFile = new RDAPValidationResultFile(results,
-        config, configurationFile, fileSystem);
-
-    /* If the parameter (--use-local-dataset) is set, use the dataset found in the filesystem,
-     * download the dataset not found in the filesystem, and persist them in the filesystem.
-     * If the parameter (--use-local-dataset) is not set, download all the dataset, and
-     * overwrite the dataset in the filesystem.
-     * If one or more dataset cannot be downloaded, exit with a return code of 2.
-     */
-    if (!datasetService.download(this.config.useLocalDatasets())) {
-      return RDAPValidationStatus.DATASET_UNAVAILABLE.getValue();
+    public RDAPValidator(RDAPValidatorConfiguration config,
+                         FileSystem fileSystem,
+                         RDAPQueryTypeProcessor queryTypeProcessor,
+                         RDAPQuery query,
+                         ConfigurationFileParser configParser,
+                         RDAPValidatorResults results,
+                         RDAPDatasetService datasetService) {
+        this.config = config;
+        this.fileSystem = fileSystem;
+        this.query = query;
+        if (!this.config.check()) {
+            logger.error("Please fix the configuration");
+            throw new RuntimeException("Please fix the configuration");
+        }
+        this.queryTypeProcessor = queryTypeProcessor;
+        this.configParser = configParser;
+        this.results = results;
+        this.datasetService = datasetService;
     }
 
-    if (!queryTypeProcessor.check(datasetService)) {
-      return queryTypeProcessor.getErrorStatus().getValue();
-    }
+    @Override
+    public int validate() {
+        ConfigurationFile configurationFile;
+        SchemaValidator validator = null;
+        Map<RDAPQueryType, String> schemaMap = Map.of(
+            RDAPQueryType.DOMAIN, "rdap_domain.json",
+            RDAPQueryType.HELP, "rdap_help.json",
+            RDAPQueryType.NAMESERVER, "rdap_nameserver.json",
+            RDAPQueryType.NAMESERVERS, "rdap_nameservers.json",
+            RDAPQueryType.ENTITY, "rdap_entity_without_asEventActor.json"
+        );
 
-    query.setResults(results);
-    if (!query.run()) {
-      query.getStatusCode().ifPresent(rdapValidationResultFile::build);
-      return query.getErrorStatus().getValue();
-    }
+        // Parse the configuration definition file, and if the file is not parsable, exit with a return code of 1.
+        try (InputStream is = fileSystem.uriToStream(this.config.getConfigurationFile())) {
+            configurationFile = configParser.parse(is);
+        } catch (Exception e) {
+            logger.error("Configuration is invalid", e);
+            return dumpErrorInfo(RDAPValidationStatus.CONFIG_INVALID.getValue(), config, query);
+        }
 
-    if (!query.checkWithQueryType(queryTypeProcessor.getQueryType())) {
-      query.getStatusCode().ifPresent(rdapValidationResultFile::build);
-      return RDAPValidationStatus.EXPECTED_OBJECT_NOT_FOUND.getValue();
-    }
+        final RDAPValidationResultFile rdapValidationResultFile = new RDAPValidationResultFile(results, config,
+            configurationFile, fileSystem);
 
-    SchemaValidator validator = null;
-    if (query.isErrorContent()) {
-      validator = new SchemaValidator("rdap_error.json", results, datasetService);
-    } else if (RDAPQueryType.DOMAIN.equals(queryTypeProcessor.getQueryType())) {
-      validator = new SchemaValidator("rdap_domain.json", results, datasetService);
-    } else if (RDAPQueryType.HELP.equals(queryTypeProcessor.getQueryType())) {
-      validator = new SchemaValidator("rdap_help.json", results, datasetService);
-    } else if (RDAPQueryType.NAMESERVER.equals(queryTypeProcessor.getQueryType())) {
-      validator = new SchemaValidator("rdap_nameserver.json", results, datasetService);
-    } else if (RDAPQueryType.NAMESERVERS.equals(queryTypeProcessor.getQueryType())) {
-      validator = new SchemaValidator("rdap_nameservers.json", results, datasetService);
-    } else if (RDAPQueryType.ENTITY.equals(queryTypeProcessor.getQueryType())) {
-      if (config.isThin()) {
-        logger.error("Thin flag is set while validating entity");
+        // If the parameter (--use-local-dataset) is set, use the dataset found in the filesystem,
+        // download the dataset not found in the filesystem, and persist them in the filesystem.
+        // If the parameter (--use-local-dataset) is not set, download all the dataset, and
+        // overwrite the dataset in the filesystem.
+        // If one or more dataset cannot be downloaded, exit with a return code of 2.
+        if (!datasetService.download(this.config.useLocalDatasets())) {
+            return dumpErrorInfo(RDAPValidationStatus.DATASET_UNAVAILABLE.getValue(), config, query);
+        }
+
+        if (!queryTypeProcessor.check(datasetService)) {
+            return dumpErrorInfo(queryTypeProcessor.getErrorStatus().getValue(), config, query);
+        }
+
+        query.setResults(results);
+        if (!query.run()) {
+            query.getStatusCode().ifPresent(rdapValidationResultFile::build);
+            return dumpErrorInfo(query.getErrorStatus().getValue(), config, query);
+        }
+
+        if (!query.checkWithQueryType(queryTypeProcessor.getQueryType())) {
+            query.getStatusCode().ifPresent(rdapValidationResultFile::build);
+            return dumpErrorInfo(RDAPValidationStatus.EXPECTED_OBJECT_NOT_FOUND.getValue(), config, query);
+        }
+
+        // Schema validation
+        if (query.isErrorContent()) {
+            validator = new SchemaValidator("rdap_error.json", results, datasetService);
+        } else {
+            String schemaFile = schemaMap.get(queryTypeProcessor.getQueryType());
+            if (schemaFile != null) {
+                if (RDAPQueryType.ENTITY.equals(queryTypeProcessor.getQueryType()) && config.isThin()) {
+                    logger.error("Thin flag is set while validating entity");
+                    query.getStatusCode().ifPresent(rdapValidationResultFile::build);
+                    return dumpErrorInfo(RDAPValidationStatus.USES_THIN_MODEL.getValue(), config, query);
+                }
+                // asEventActor property is not allow in topMost entity object, see spec 7.2.9.2
+                validator = new SchemaValidator(schemaFile, results, datasetService);
+            }
+        }
+
+        assert null != validator;
+        validator.validate(query.getData());
+        HttpResponse<String> rdapResponse = (HttpResponse<String>) query.getRawResponse();
+
+        // extra validations not categorized (change request):
+        // query.isErrorContent() added as condition in cases where they have 404 as status code
+        if (rdapResponse != null && !query.isErrorContent()) {
+            new DomainCaseFoldingValidation(rdapResponse, config, results,
+                queryTypeProcessor.getQueryType()).validate();
+        }
+
+        // Additionally, apply the relevant collection tests when the option
+        // --use-rdap-profile-february-2019 or --use-rdap-profile-february-2024 is set
+        // query.isErrorContent() added as condition in cases where they have 404 as status code
+        if ((config.useRdapProfileFeb2019() || config.useRdapProfileFeb2024()) && !query.isErrorContent()) {
+            logger.info("Validations for 2019 profile");
+            RDAPProfile rdapProfile = new RDAPProfile(getRdapValidations(rdapResponse, config, results, datasetService, queryTypeProcessor, validator, query));
+            rdapProfile.validate();
+        }
+
+        // Additionally, apply the relevant collection tests when the option
+        // --use-rdap-profile-february-2024 is set
+        // query.isErrorContent() added as condition in cases where they have 404 as status code
+        if (config.useRdapProfileFeb2024() && !query.isErrorContent()) {
+            logger.info("Validations for 2024 profile");
+            RDAPProfile rdapProfile = new RDAPProfile(List.of(new TigValidation1Dot3_2024(query.getData(), results)));
+            rdapProfile.validate();
+        }
+
+        // finally we set the statusCode and results path
         query.getStatusCode().ifPresent(rdapValidationResultFile::build);
-        return RDAPValidationStatus.USES_THIN_MODEL.getValue();
-      }
-      // asEventActor property is not allow in topMost entity object, see spec 7.2.9.2
-      validator = new SchemaValidator("rdap_entity_without_asEventActor.json", results,
-          datasetService);
-    }
-    assert null != validator;
-    validator.validate(query.getData());
-    HttpResponse<String> rdapResponse = (HttpResponse<String>) query.getRawResponse();
+        this.resultsPath = rdapValidationResultFile.resultPath;
 
-    // extra validations not categorized (change request):
-    // query.isErrorContent() added as condition in cases where they have 404 as status code
-    if (rdapResponse != null && !query.isErrorContent()) {
-      new DomainCaseFoldingValidation(rdapResponse, config, results,
-          queryTypeProcessor.getQueryType()).validate();
-    }
-    
-    /*
-     * Additionally, apply the relevant collection tests when the option
-     * --use-rdap-profile-february-2019 or --use-rdap-profile-february-2024 is set
-     * query.isErrorContent() added as condition in cases where they have 404 as status code
-     */
-    if ((config.useRdapProfileFeb2019() || config.useRdapProfileFeb2024()) && !query.isErrorContent()) {
-        logger.info("Validations for 2019 profile");
-        RDAPProfile rdapProfile = new RDAPProfile(
-          List.of(
-              new TigValidation1Dot2(rdapResponse, config, results),
-              new TigValidation1Dot3(rdapResponse, config, results),
-              new TigValidation1Dot6(rdapResponse.statusCode(), config, results),
-              new TigValidation1Dot8(rdapResponse, results, datasetService),
-              new TigValidation1Dot13(rdapResponse, results),
-              new TigValidation1Dot11Dot1(config, results, datasetService,
-                  queryTypeProcessor.getQueryType()),
-              new TigValidation1Dot14(query.getData(), results),
-              new TigValidation3Dot2(query.getData(), results, config, datasetService,
-                  queryTypeProcessor.getQueryType()),
-              new TigValidation6Dot1(query.getData(), results, queryTypeProcessor.getQueryType()),
-              new TigValidation3Dot3And3Dot4(query.getData(), results, validator),
-              new TigValidation4Dot1(query.getData(), results),
-              new TigValidation7Dot1And7Dot2(query.getData(), results),
-              new TigValidation1Dot12Dot1(query.getData(), results, datasetService,
-                  queryTypeProcessor.getQueryType()),
-              new ResponseValidation1Dot2Dot2(query.getData(), results),
-              new ResponseValidation1Dot3(query.getData(), results),
-              new ResponseValidation1Dot4(query.getData(), results),
-              new ResponseValidationLastUpdateEvent(query.getData(), results,
-                  queryTypeProcessor.getQueryType()),
-              new ResponseValidation2Dot1(query.getData(), results, config,
-                  queryTypeProcessor.getQueryType()),
-              new ResponseValidation2Dot2(config, query.getData(), results, datasetService,
-                  queryTypeProcessor.getQueryType()),
-              new ResponseValidation2Dot3Dot1Dot1(query.getData(), results,
-                  queryTypeProcessor.getQueryType()),
-              new ResponseValidation2Dot3Dot1Dot2(query.getData(), results,
-                  queryTypeProcessor.getQueryType()),
-              new ResponseValidationNoticesIncluded(query.getData(), results,
-                  queryTypeProcessor.getQueryType()),
-              new ResponseValidation2Dot6Dot3(query.getData(), results,
-                  queryTypeProcessor.getQueryType()),
-              new ResponseValidation2Dot11(query.getData(), results,
-                  queryTypeProcessor.getQueryType()),
-              new ResponseValidation2Dot10(query.getData(), results,
-                  queryTypeProcessor.getQueryType()),
-              new ResponseValidationRFC5731(query.getData(), results,
-                  queryTypeProcessor.getQueryType()),
-              new ResponseValidationRFC3915(query.getData(), results,
-                  queryTypeProcessor.getQueryType()),
-              new ResponseValidation2Dot6Dot1(query.getData(), results,
-                  queryTypeProcessor.getQueryType()),
-              new ResponseValidation2Dot9Dot1And2Dot9Dot2(config, query.getData(), results,
-                  datasetService, queryTypeProcessor.getQueryType()),
-              new ResponseValidation2Dot4Dot1(query.getData(), results,
-                  queryTypeProcessor.getQueryType()),
-              new ResponseValidation2Dot4Dot2And2Dot4Dot3(query.getData(), results,
-                  datasetService, queryTypeProcessor.getQueryType()),
-              new ResponseValidation2Dot4Dot5(query.getData(), results,
-                  queryTypeProcessor.getQueryType()),
-              new ResponseValidation2Dot7Dot1DotXAndRelated1(query.getData(), results,
-                  queryTypeProcessor.getQueryType(), config),
-              new ResponseValidation2Dot7Dot1DotXAndRelated2(query.getData(), results,
-                  queryTypeProcessor.getQueryType(), config),
-              new ResponseValidation2Dot7Dot1DotXAndRelated3And4(query.getData(), results,
-                  queryTypeProcessor.getQueryType(), config,
-                  new SimpleHandleValidation(query.getData(), results, datasetService,
-                      queryTypeProcessor.getQueryType(), -52102)),
-              new ResponseValidation2Dot7Dot1DotXAndRelated5(query.getData(), results,
-                  queryTypeProcessor.getQueryType(), config),
-              new ResponseValidation2Dot7Dot1DotXAndRelated6(query.getData(), results,
-                  queryTypeProcessor.getQueryType(), config),
-              new ResponseValidation2Dot7Dot5Dot2(query.getData(), results,
-                  queryTypeProcessor.getQueryType(), config),
-              new ResponseValidation2Dot7Dot5Dot3(query.getData(), results,
-                  queryTypeProcessor.getQueryType(), config),
-              new ResponseValidation3Dot1(query.getData(), results,
-                  queryTypeProcessor.getQueryType(), config),
-              new ResponseValidation3Dot2(query.getData(), results,
-                  queryTypeProcessor.getQueryType(), config),
-              new ResponseNameserverStatusValidation(query.getData(), results,
-                  queryTypeProcessor.getQueryType()),
-              new ResponseValidation4Dot1Handle(config, query.getData(), results,
-                  datasetService, queryTypeProcessor.getQueryType()),
-              new ResponseValidation4Dot1Query(query.getData(), results,
-                  config, queryTypeProcessor.getQueryType()),
-              new ResponseValidation4Dot3(query.getData(), results,
-                  datasetService, queryTypeProcessor.getQueryType())
-          ));
-      rdapProfile.validate();
+        // we do not dumpInfo here, everything is fine
+        return RDAPValidationStatus.SUCCESS.getValue();
     }
 
-    /*
-     * Additionally, apply the relevant collection tests when the option
-     * --use-rdap-profile-february-2024 is set
-     * query.isErrorContent() added as condition in cases where they have 404 as status code
-     */
-    if (config.useRdapProfileFeb2024() && !query.isErrorContent()) {
-      logger.info("Validations for 2024 profile");
-      RDAPProfile rdapProfile = new RDAPProfile(
-          List.of(
-              new TigValidation1Dot3_2024(query.getData(), results)
-          ));
-      rdapProfile.validate();
+    @Override
+    public String getResultsPath() {
+        return this.resultsPath;
     }
 
+    private List<ProfileValidation> getRdapValidations(HttpResponse<String> rdapResponse, RDAPValidatorConfiguration config, RDAPValidatorResults results, RDAPDatasetService datasetService, RDAPQueryTypeProcessor queryTypeProcessor, SchemaValidator validator, RDAPQuery query) {
+        return List.of(
+            new TigValidation1Dot2(rdapResponse, config, results),
+            new TigValidation1Dot3(rdapResponse, config, results),
+            new TigValidation1Dot6(rdapResponse.statusCode(), config, results),
+            new TigValidation1Dot8(rdapResponse, results, datasetService),
+            new TigValidation1Dot13(rdapResponse, results),
+            new TigValidation1Dot11Dot1(config, results, datasetService, queryTypeProcessor.getQueryType()),
+            new TigValidation1Dot14(query.getData(), results),
+            new TigValidation3Dot2(query.getData(), results, config, datasetService, queryTypeProcessor.getQueryType()),
+            new TigValidation6Dot1(query.getData(), results, queryTypeProcessor.getQueryType()),
+            new TigValidation3Dot3And3Dot4(query.getData(), results, validator),
+            new TigValidation4Dot1(query.getData(), results),
+            new TigValidation7Dot1And7Dot2(query.getData(), results),
+            new TigValidation1Dot12Dot1(query.getData(), results, datasetService, queryTypeProcessor.getQueryType()),
+            new ResponseValidation1Dot2Dot2(query.getData(), results),
+            new ResponseValidation1Dot3(query.getData(), results),
+            new ResponseValidation1Dot4(query.getData(), results),
+            new ResponseValidationLastUpdateEvent(query.getData(), results, queryTypeProcessor.getQueryType()),
+            new ResponseValidation2Dot1(query.getData(), results, config, queryTypeProcessor.getQueryType()),
+            new ResponseValidation2Dot2(config, query.getData(), results, datasetService, queryTypeProcessor.getQueryType()),
+            new ResponseValidation2Dot3Dot1Dot1(query.getData(), results, queryTypeProcessor.getQueryType()),
+            new ResponseValidation2Dot3Dot1Dot2(query.getData(), results, queryTypeProcessor.getQueryType()),
+            new ResponseValidationNoticesIncluded(query.getData(), results, queryTypeProcessor.getQueryType()),
+            new ResponseValidation2Dot6Dot3(query.getData(), results, queryTypeProcessor.getQueryType()),
+            new ResponseValidation2Dot11(query.getData(), results, queryTypeProcessor.getQueryType()),
+            new ResponseValidation2Dot10(query.getData(), results, queryTypeProcessor.getQueryType()),
+            new ResponseValidationRFC5731(query.getData(), results, queryTypeProcessor.getQueryType()),
+            new ResponseValidationRFC3915(query.getData(), results, queryTypeProcessor.getQueryType()),
+            new ResponseValidation2Dot6Dot1(query.getData(), results, queryTypeProcessor.getQueryType()),
+            new ResponseValidation2Dot9Dot1And2Dot9Dot2(config, query.getData(), results, datasetService, queryTypeProcessor.getQueryType()),
+            new ResponseValidation2Dot4Dot1(query.getData(), results, queryTypeProcessor.getQueryType()),
+            new ResponseValidation2Dot4Dot2And2Dot4Dot3(query.getData(), results, datasetService, queryTypeProcessor.getQueryType()),
+            new ResponseValidation2Dot4Dot5(query.getData(), results, queryTypeProcessor.getQueryType()),
+            new ResponseValidation2Dot7Dot1DotXAndRelated1(query.getData(), results, queryTypeProcessor.getQueryType(), config),
+            new ResponseValidation2Dot7Dot1DotXAndRelated2(query.getData(), results, queryTypeProcessor.getQueryType(), config),
+            new ResponseValidation2Dot7Dot1DotXAndRelated3And4(query.getData(), results, queryTypeProcessor.getQueryType(), config, new SimpleHandleValidation(query.getData(), results, datasetService, queryTypeProcessor.getQueryType(), -52102)),
+            new ResponseValidation2Dot7Dot1DotXAndRelated5(query.getData(), results, queryTypeProcessor.getQueryType(), config),
+            new ResponseValidation2Dot7Dot1DotXAndRelated6(query.getData(), results, queryTypeProcessor.getQueryType(), config),
+            new ResponseValidation2Dot7Dot5Dot2(query.getData(), results, queryTypeProcessor.getQueryType(), config),
+            new ResponseValidation2Dot7Dot5Dot3(query.getData(), results, queryTypeProcessor.getQueryType(), config),
+            new ResponseValidation3Dot1(query.getData(), results, queryTypeProcessor.getQueryType(), config),
+            new ResponseValidation3Dot2(query.getData(), results, queryTypeProcessor.getQueryType(), config),
+            new ResponseNameserverStatusValidation(query.getData(), results, queryTypeProcessor.getQueryType()),
+            new ResponseValidation4Dot1Handle(config, query.getData(), results, datasetService, queryTypeProcessor.getQueryType()),
+            new ResponseValidation4Dot1Query(query.getData(), results, config, queryTypeProcessor.getQueryType()),
+            new ResponseValidation4Dot3(query.getData(), results, datasetService, queryTypeProcessor.getQueryType())
+        );
+    }
 
-    query.getStatusCode().ifPresent(rdapValidationResultFile::build);
+    private int dumpErrorInfo(int exitCode, RDAPValidatorConfiguration config, RDAPQuery query) {
+        System.out.println("Exit code: " + exitCode + " - " + RDAPValidationStatus.fromValue(exitCode).name());
+        System.out.println("URI used for the query: " + config.getUri());
+        if (query instanceof RDAPHttpQuery httpQuery) {
+            System.out.println("Redirects followed: " + httpQuery.getRedirects());
+            System.out.println("Accept header used for the query: " + httpQuery.getAcceptHeader());
+        } else {
+            System.out.println("Redirects followed: N/A (query is not an RDAPHttpQuery)");
+            System.out.println("Accept header used for the query: N/A (query is not an RDAPHttpQuery)");
+        }
+        if (config.getUri() != null && config.getUri().getHost() != null) {
+            System.out.println(
+                "IP protocol used for the query: " + (config.getUri().getHost().contains(":") ? "IPv6" : "IPv4"));
+        } else {
+            System.out.println("IP protocol used for the query: unknown (URI or host is null)");
+        }
 
-    this.resultsPath = rdapValidationResultFile.resultPath;
-    return RDAPValidationStatus.SUCCESS.getValue();
-  }
-
-  @Override
-  public String getResultsPath() {
-      return this.resultsPath;
-  }
+        return exitCode;
+    }
 }
+
+

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
@@ -155,7 +155,7 @@ public class RDAPHttpQuery implements RDAPQuery {
     return status;
   }
 
-    private void makeRequest() {
+    public void makeRequest() {
       try {
             URI currentUri = this.config.getUri();
             int remainingRedirects = this.config.getMaxRedirects();
@@ -199,7 +199,7 @@ public class RDAPHttpQuery implements RDAPQuery {
             }
 
             httpResponse = response;
-        } catch (IOException | InterruptedException e) {
+        } catch (Exception e) {
           handleRequestException(e); // catch for all subclasses of these exceptions
         }
     }
@@ -234,7 +234,6 @@ public class RDAPHttpQuery implements RDAPQuery {
                                             .build());
         }
 
-        System.out.println("Check the JSON data....");
         // If a response is available to the tool, but it's not syntactically valid JSON object, error code -13001 added in results file.
         jsonResponse = new JsonData(rdapResponse);
         if (!jsonResponse.isValid()) {
@@ -245,14 +244,11 @@ public class RDAPHttpQuery implements RDAPQuery {
                                             .build());
 
           isQuerySuccessful = false;
-            System.out.println("Invalid JSON data -- return early");
           return;
         }
 
-        System.out.println("Check the HTTP status code....");
         // If a response is available to the tool, but the HTTP status code is not 200 nor 404, error code -13002 added in results file
         if (!List.of(HTTP_OK, HTTP_NOT_FOUND).contains(httpStatusCode)) {
-            System.out.println("Invalid HTTP status " + httpStatusCode);
             logger.error("Invalid HTTP status {}", httpStatusCode);
             results.add(RDAPValidationResult.builder()
                                             .code(-13002)
@@ -295,7 +291,6 @@ public class RDAPHttpQuery implements RDAPQuery {
      */
   private void handleRequestException(Exception e) {
     logger.info("Exception during RDAP query", e);
-
     if (e instanceof ConnectException || e instanceof HttpTimeoutException) {
       status = hasCause(e, "java.nio.channels.UnresolvedAddressException")
           ? RDAPValidationStatus.NETWORK_SEND_FAIL

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/HttpTestingUtils.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/HttpTestingUtils.java
@@ -54,36 +54,6 @@ public abstract class HttpTestingUtils {
   public void setUp() {
     doReturn(10).when(config).getTimeout();
     doReturn(3).when(config).getMaxRedirects();
-    String response = "{\"NoObjectClassName\": \"domain\"}";
-    String responseNameServer = "{\"nameserverSearchResults\": { \"objectClassName\":\"nameserver\" }}";
-    doReturn(Set.of(
-            RDAPValidationResult.builder()
-                    .code(-13000)
-                    .value("Content-Type")
-                    .message("The content-type header does not contain the application/rdap+json media type.")
-                    .build(),
-            RDAPValidationResult.builder()
-                    .code(-13001)
-                    .value("response body not given")
-                    .message("The response was not valid JSON.")
-                    .build(),
-            RDAPValidationResult.builder()
-                    .code(-13002)
-                    .value("403")
-                    .message("The HTTP status code was neither 200 nor 404.")
-                    .build(),
-            RDAPValidationResult.builder()
-                    .code(-13003)
-                    .value(response)
-                    .message("The response does not have an objectClassName string.")
-                    .build(),
-            RDAPValidationResult.builder()
-                    .code(-13003)
-                    .value(responseNameServer)
-                    .message("The response does not have an objectClassName string.")
-                    .build()
-            ))
-            .when(results).getAll();
   }
 
   @AfterMethod


### PR DESCRIPTION
CHANGE: client outputs are fixed to stdout when exitCode is NOT zero and prints relevant info. Also, quite a bit of refactoring to make things more readable and added code coverage.