### PR TITLE
feat/RCT-90-AddFileWriteError

### DIFF
--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidationResultFile.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidationResultFile.java
@@ -52,7 +52,7 @@ public class RDAPValidationResultFile {
   /**
    * Fill and save the result file.
    */
-  public void build(int statusCode) {
+  public boolean build(int statusCode) {
     Map<String, Object> fileMap = new HashMap<>();
     fileMap.put("definitionIdentifier", configurationFile.getDefinitionIdentifier());
     fileMap.put("testedURI", config.getUri());
@@ -78,8 +78,10 @@ public class RDAPValidationResultFile {
       }
       this.resultPath = path.toString();
       fileSystem.write(path.toString(), object.toString(4));
+      return true;
     } catch (IOException e) {
       logger.error("Failed to write results into {}", path, e);
+      return false;
     }
   }
 

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidationStatus.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidationStatus.java
@@ -20,7 +20,8 @@ public enum RDAPValidationStatus {
   HTTP_ERROR(17, "HTTP errors."),
   HTTP2_ERROR(18, "HTTP/2 errors."),
   NETWORK_SEND_FAIL(19, "Failure sending network data."),
-  NETWORK_RECEIVE_FAIL(20, "Failure in receiving network data.");
+  NETWORK_RECEIVE_FAIL(20, "Failure in receiving network data."),
+  FILE_WRITE_ERROR(23, "Failure in writing to results file");
 
   private final int value;
   private final String description;

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
@@ -120,7 +120,7 @@ public class RDAPHttpQuery implements RDAPQuery {
         addErrorToResultsFile(-13003, httpResponse.body(),"The response does not have an objectClassName string.");
       }
     }
-    return true;
+    return true; // this always returns true
   }
 
     @Override

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidatorTest.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidatorTest.java
@@ -169,36 +169,6 @@ public class RDAPValidatorTest {
   }
 
   @Test
-  public void testValidate_QueryCheckWithQueryTypeReturnsFalse_ReturnsError() throws IOException {
-    RDAPValidatorConfiguration config = mock(RDAPValidatorConfiguration.class);
-    FileSystem fileSystem = mock(FileSystem.class);
-    RDAPQueryTypeProcessor queryTypeProcessor = mock(RDAPQueryTypeProcessor.class);
-    RDAPQuery query = mock(RDAPQuery.class);
-    ConfigurationFileParser configParser = mock(ConfigurationFileParser.class);
-    RDAPValidatorResults results = mock(RDAPValidatorResults.class);
-    RDAPDatasetService datasetService = mock(RDAPDatasetService.class);
-    RDAPValidationResultFile rdapValidationResultFile = mock(RDAPValidationResultFile.class);
-
-    doReturn(true).when(config).check();
-    doReturn(true).when(queryTypeProcessor).check(datasetService);
-    doReturn(true).when(datasetService).download(anyBoolean());
-    doReturn(new ConfigurationFile("Test", null, null, null, null)).when(configParser).parse(any());
-    RDAPQueryType queryType = RDAPQueryType.DOMAIN;
-    doReturn(queryType).when(queryTypeProcessor).getQueryType();
-    doReturn(true).when(query).run(); // Ensure query.run() returns true
-    doReturn(false).when(query).checkWithQueryType(queryType); // Ensure checkWithQueryType returns false
-    doReturn(Optional.of(123)).when(query).getStatusCode();
-    doReturn(RDAPValidationStatus.UNSUPPORTED_QUERY).when(query).getErrorStatus();
-
-    RDAPValidator validator = new RDAPValidator(config, fileSystem, queryTypeProcessor, query, configParser, results, datasetService);
-
-    int result = validator.validate();
-
-    assertThat(result).isEqualTo(RDAPValidationStatus.UNSUPPORTED_QUERY.getValue());
-    verify(query).getStatusCode();
-  }
-
-  @Test
   public void testValidate_DomainQueryForTestInvalidWithHttpOK_LogsInfo() throws IOException {
     RDAPValidatorConfiguration config = mock(RDAPValidatorConfiguration.class);
     FileSystem fileSystem = mock(FileSystem.class);


### PR DESCRIPTION
CHANGE:
Added logic for correctly exiting with code 23 if we are not able to write to the results file.
I also removed the test that tested our call to `query.checkWithQueryType(queryTypeProcessor.getQueryType())` as that is complete BS as we _always_ return true on that.