### PR TITLE
chore/RCT-43-RefactorDocumentationAndMethodcall

### DIFF
--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/QueryValidation.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/QueryValidation.java
@@ -47,7 +47,7 @@ public abstract class QueryValidation extends ProfileJsonValidation {
     IDNA.Info info = new IDNA.Info();
     idna.nameToASCII(domainName, ldhNameBuilder, info);
     if (info.hasErrors()) {
-      logger.error("Invalid domain name");
+      logger.info("Invalid domain name");
       return false;
     }
 

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/general/ResponseValidationLinkElements_2024.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/general/ResponseValidationLinkElements_2024.java
@@ -56,7 +56,7 @@ public class ResponseValidationLinkElements_2024 extends ProfileValidation {
                     }
                 }
             } catch (Exception e) {
-                logger.error("Exception during evaluation of link properties: {} \n\n details: {}", jsonObject.query(jsonPointer), e);
+                logger.info("Exception during evaluation of link properties: {} \n\n details: {}", jsonObject.query(jsonPointer), e);
             }
         }
         return isOK;

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/general/ResponseValidationStatusDuplication_2024.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/general/ResponseValidationStatusDuplication_2024.java
@@ -60,7 +60,7 @@ public class ResponseValidationStatusDuplication_2024 extends ProfileValidation 
                 }
             }
         } catch (Exception e) {
-            logger.error("Exception during evaluation of status properties: {} \n\n details: {}", jsonObject, e);
+            logger.info("Exception during evaluation of status properties: {} \n\n details: {}", jsonObject, e);
             isOK = false;
         }
         return isOK;

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/general/ResponseValidationTestInvalidRedirect_2024.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/general/ResponseValidationTestInvalidRedirect_2024.java
@@ -51,7 +51,7 @@ public class ResponseValidationTestInvalidRedirect_2024 extends ProfileValidatio
                 return handleRedirect(response);
             }
         } catch (Exception e) {
-            logger.error("Exception when making HTTP GET request in [generalResponseValidation]", e);
+            logger.info("Exception when making HTTP GET request in [generalResponseValidation]", e);
             return false;
         }
 
@@ -77,7 +77,7 @@ public class ResponseValidationTestInvalidRedirect_2024 extends ProfileValidatio
                 return false;
             }
         } catch (Exception e) {
-            logger.error("Error normalizing Location header: {}", locationHeader, e);
+            logger.info("Error normalizing Location header: {}", locationHeader, e);
             return false;
         }
 

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/tig_section/general/TigValidation1Dot5_2024.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/tig_section/general/TigValidation1Dot5_2024.java
@@ -55,7 +55,7 @@ public class TigValidation1Dot5_2024 extends ProfileValidation {
                 try {
                     sslContext = SSLContext.getDefault();
                 } catch (NoSuchAlgorithmException e) {
-                    logger.error("Cannot create SSL context", e);
+                    logger.info("Cannot create SSL context", e);
                     return false;
                 }
 

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/tig_section/general/TigValidation1Dot6.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/tig_section/general/TigValidation1Dot6.java
@@ -41,7 +41,7 @@ public final class TigValidation1Dot6 extends ProfileValidation {
         return false;
       }
     } catch (Exception e) {
-      logger.error(
+      logger.info(
           "Exception when making HTTP HEAD request in order to check [tigSection_1_6_Validation]",
           e);
       return false;

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/tig_section/general/TigValidation1Dot8.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/tig_section/general/TigValidation1Dot8.java
@@ -68,7 +68,7 @@ public final class TigValidation1Dot8 extends ProfileValidation {
     try {
       host = Name.fromString(uri.getHost());
     } catch (TextParseException e) {
-      logger.error("Error when retrieving RDAP server hostname in order to check "
+      logger.info("Error when retrieving RDAP server hostname in order to check "
           + "[tigSection_1_8_Validation]", e);
       return true;
     }

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/tig_section/registry/TigValidation1Dot11Dot1.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/tig_section/registry/TigValidation1Dot11Dot1.java
@@ -90,7 +90,7 @@ public final class TigValidation1Dot11Dot1 extends ProfileValidation {
     try {
       uri = new URI(uri.getScheme(), uri.getHost(), uri.getPath(), uri.getFragment());
     } catch (URISyntaxException e) {
-      logger.error("URI has a syntax issue: ", e);
+      logger.info("URI has a syntax issue: ", e);
       return StringUtils.EMPTY;
     }
     return uri.toString();

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.net.URI;
-import java.net.UnknownHostException;
+
 import java.net.http.HttpHeaders;
 import java.net.http.HttpResponse;
 import java.net.http.HttpTimeoutException;
@@ -43,6 +43,7 @@ public class RDAPHttpQuery implements RDAPQuery {
     public static final String NETWORKS = "networks";
     public static final String ERROR_CODE = "errorCode";
     public static final String RDAP_CONFORMANCE = "rdapConformance";
+    public static final String NAMESERVER_SEARCH_RESULTS = "nameserverSearchResults";
 
     private List<URI> redirects = new ArrayList<>();
     private String acceptHeader;
@@ -127,10 +128,10 @@ public class RDAPHttpQuery implements RDAPQuery {
            */
         if (httpResponse.statusCode() == HTTP_OK) {
           if (queryType.isLookupQuery() && !hasNameserverSearchResults()) {
-            logger.error("objectClassName was not found in the topmost object");
+            logger.info("objectClassName was not found in the topmost object");
               addErrorToResultsFile(-13003, httpResponse.body(), "The response does not have an objectClassName string.");
           } else if (queryType.equals(RDAPQueryType.NAMESERVERS) && !hasNameserverSearchResults()) {
-            logger.error("No JSON array in answer");
+            logger.info("No JSON array in answer");
             if (config.useRdapProfileFeb2024()) {
                 addErrorToResultsFile(-12610, httpResponse.body(), "The nameserverSearchResults structure is required.");
             } else {
@@ -266,7 +267,7 @@ public class RDAPHttpQuery implements RDAPQuery {
 
         // If a response is available to the tool, but the HTTP status code is not 200 nor 404, error code -13002 added in results file
         if (!List.of(HTTP_OK, HTTP_NOT_FOUND).contains(httpStatusCode)) {
-            logger.error("Invalid HTTP status {}", httpStatusCode);
+            logger.info("Invalid HTTP status {}", httpStatusCode);
             addErrorToResultsFile(-13002, String.valueOf(httpStatusCode), "The HTTP status code was neither 200 nor 404.");
             isQuerySuccessful = false;
         }
@@ -377,8 +378,8 @@ public class RDAPHttpQuery implements RDAPQuery {
      * @return true if the response contains a valid nameserverSearchResults collection
      */
     boolean hasNameserverSearchResults() {
-        return null != jsonResponse && jsonResponse.hasKey("nameserverSearchResults")
-            && jsonResponse.getValue("nameserverSearchResults") instanceof Collection<?>;
+        return null != jsonResponse && jsonResponse.hasKey(NAMESERVER_SEARCH_RESULTS)
+            && jsonResponse.getValue(NAMESERVER_SEARCH_RESULTS) instanceof Collection<?>;
     }
 
   private boolean hasCause(Throwable e, String causeClassName) {

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQueryTest.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQueryTest.java
@@ -117,7 +117,7 @@ public class RDAPHttpQueryTest extends HttpTestingUtils {
     assertThat(rdapHttpQuery.run()).isTrue();
     assertThat(rdapHttpQuery.getData()).isEqualTo(RDAP_RESPONSE);
     assertThat(rdapHttpQuery.getStatusCode()).isPresent().get().isEqualTo(200);
-    assertThat(rdapHttpQuery.jsonIsSearchResponse()).isFalse();
+    assertThat(rdapHttpQuery.hasNameserverSearchResults()).isFalse();
   }
 
   @Test(dataProvider = "fault")
@@ -151,7 +151,7 @@ public class RDAPHttpQueryTest extends HttpTestingUtils {
     assertThat(rdapHttpQuery.run()).isTrue();
     assertThat(rdapHttpQuery.getData()).isEqualTo(RDAP_RESPONSE);
     assertThat(rdapHttpQuery.getStatusCode()).isPresent().get().isEqualTo(200);
-    assertThat(rdapHttpQuery.jsonIsSearchResponse()).isFalse();
+    assertThat(rdapHttpQuery.hasNameserverSearchResults()).isFalse();
   }
 
   @Test
@@ -172,7 +172,7 @@ public class RDAPHttpQueryTest extends HttpTestingUtils {
     assertThat(rdapHttpQuery.run()).isTrue();
     assertThat(rdapHttpQuery.getData()).isEqualTo(response);
     assertThat(rdapHttpQuery.getStatusCode()).isPresent().get().isEqualTo(200);
-    assertThat(rdapHttpQuery.jsonIsSearchResponse()).isTrue();
+    assertThat(rdapHttpQuery.hasNameserverSearchResults()).isTrue();
   }
 
   @Test(dataProvider = "fault")


### PR DESCRIPTION
CHANGE: 
Rename the method call so that it is named to what it actually does and update the current documentation.
I also change several logger.errors to logger.infos
.errrors should be for when the tool can't actually run and do its job, everything else gets reported under .info with the -v flag