### PR TITLE
feat/RCT-155-RdapResponseProfile_4_1_Validation 

### DIFF
--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/HandleValidation.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/HandleValidation.java
@@ -9,6 +9,7 @@ import org.icann.rdapconformance.validator.workflow.rdap.dataset.model.EPPRoid;
 
 public abstract class HandleValidation extends ProfileJsonValidation {
 
+  public static final String ICANNRST = "ICANNRST";
   private final RDAPDatasetService datasetService;
   protected final RDAPQueryType queryType;
   final int code;
@@ -52,6 +53,17 @@ public abstract class HandleValidation extends ProfileJsonValidation {
           .build());
       return false;
     }
+
+    if (roid.contains(ICANNRST) && this.queryType.equals(RDAPQueryType.NAMESERVER)) {
+      results.add(RDAPValidationResult.builder()
+                                      .code(-49104)
+                                      .value(getResultValue(handleJsonPointer))
+                                      .message(
+                                          "The globally unique identifier in the nameserver object handle is using an EPPROID reserved for testing by ICANN.")
+                                      .build());
+      return false;
+    }
+
     return true;
   }
 }

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/nameserver/ResponseValidation4Dot1HandleTest.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/nameserver/ResponseValidation4Dot1HandleTest.java
@@ -2,6 +2,7 @@ package org.icann.rdapconformance.validator.workflow.profile.rdap_response.names
 
 import org.icann.rdapconformance.validator.workflow.profile.rdap_response.HandleValidationTest;
 import org.icann.rdapconformance.validator.workflow.rdap.RDAPQueryType;
+import org.testng.annotations.Test;
 
 public class ResponseValidation4Dot1HandleTest extends
     HandleValidationTest<ResponseValidation4Dot1Handle> {
@@ -17,9 +18,22 @@ public class ResponseValidation4Dot1HandleTest extends
     return "#/handle:ABCD";
   }
 
+  protected String givenReservedICANNHandle() {
+    replaceValue("handle", "ABCD-ICANNRST");
+    return "#/handle:ABCD-ICANNRST";
+  }
+
   @Override
   protected String getValidValueWithRoidExmp() {
     return "#/handle:2138514_NS_COM-EXMP";
   }
 
+
+  @Test
+  public void testValidate_HandleIsInvalid_AddErrorCode() {
+    String value = givenReservedICANNHandle();
+    getProfileValidation();
+    validate(-49104, value,
+        "The globally unique identifier in the nameserver object handle is using an EPPROID reserved for testing by ICANN.");
+  }
 }


### PR DESCRIPTION
CHANGE:
checks the nameserver object for the reserved string: ICANNRST