### PR TITLE
feat/RCT-150, 151, 152 and 153

### DIFF
--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/HandleValidation.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/HandleValidation.java
@@ -10,9 +10,16 @@ import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidationResult;
 import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidatorResults;
 import org.icann.rdapconformance.validator.workflow.rdap.dataset.model.EPPRoid;
 
+
+/**
+ * Used by the following validations:
+ *  ResponseValidation2Dot2
+ *  ResponseValidation2Dot7Dot1DotXAndRelated3And4 (via SimpleHandleValidation)
+ *  ResponseValidation2Dot9Dot1And2Dot9Dot2
+ *  ResponseValidation4Dot1Handle
+ */
 public abstract class HandleValidation extends ProfileJsonValidation {
 
-  public static final String ICANNRST = "ICANNRST";
   private final RDAPDatasetService datasetService;
   protected final RDAPQueryType queryType;
   private RDAPValidatorConfiguration config;
@@ -59,28 +66,6 @@ public abstract class HandleValidation extends ProfileJsonValidation {
           .build());
       return false;
     }
-
-    if (roid.contains(ICANNRST) && this.queryType.equals(RDAPQueryType.NAMESERVER) && this.config.useRdapProfileFeb2024()) {
-      results.add(RDAPValidationResult.builder()
-                                      .code(-49104)
-                                      .value(getResultValue(handleJsonPointer))
-                                      .message(
-                                          "The globally unique identifier in the nameserver object handle is using an EPPROID reserved for testing by ICANN.")
-                                      .build());
-      return false;
-    }
-
-
-    if (roid.endsWith(ICANNRST) && this.queryType.equals(RDAPQueryType.DOMAIN) && this.config.useRdapProfileFeb2024()) {
-      results.add(RDAPValidationResult.builder()
-                                      .code(-46205)
-                                      .value(getResultValue(handleJsonPointer))
-                                      .message(
-                                          "The globally unique identifier in the domain object handle is using an EPPROID reserved for testing by ICANN.")
-                                      .build());
-      return false;
-    }
-
     return true;
   }
 }

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/ResponseValidation2Dot2_2024.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/ResponseValidation2Dot2_2024.java
@@ -1,0 +1,53 @@
+package org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain;
+
+import org.icann.rdapconformance.validator.workflow.profile.ProfileJsonValidation;
+import org.icann.rdapconformance.validator.workflow.rdap.RDAPQueryType;
+import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidationResult;
+import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidatorResults;
+
+public final class ResponseValidation2Dot2_2024 extends ProfileJsonValidation {
+    private final RDAPQueryType queryType;
+
+    public ResponseValidation2Dot2_2024(String rdapResponse, RDAPValidatorResults results, RDAPQueryType queryType) {
+        super(rdapResponse, results);
+
+        this.queryType = queryType;
+    }
+
+    @Override
+    public String getGroupName() {
+        return "rdapResponseProfile_2_2_Validation";
+    }
+
+    @Override
+    protected boolean doValidate() {
+        String handle = "";
+
+        Object obj = jsonObject.query("#/handle");
+        if (obj != null) {
+            // have to use .toString() instead of cast (String),
+            // because if the value is JSONObject.NULL, it won't cast
+            // added testValidate_HandleIsNull_AddErrorCode unit test for this
+            handle = obj.toString();
+        }
+
+        if (handle != null && handle.endsWith("-ICANNRST")) {
+            results.add(RDAPValidationResult.builder()
+                .code(-46205)
+                .value(getResultValue("#/handle"))
+                .message(
+                    "The globally unique identifier in the domain object handle is using an EPPROID reserved for testing by ICANN.")
+                .build());
+
+            return false;
+        }
+
+        return true;
+    }
+
+
+    @Override
+    public boolean doLaunch() {
+        return queryType.equals(RDAPQueryType.DOMAIN);
+    }
+}

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/ResponseValidation2Dot9Dot1And2Dot9Dot2.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/ResponseValidation2Dot9Dot1And2Dot9Dot2.java
@@ -1,8 +1,5 @@
 package org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain;
 
-import static org.icann.rdapconformance.validator.CommonUtils.HYPHEN;
-import static org.icann.rdapconformance.validator.CommonUtils.ONE;
-import static org.icann.rdapconformance.validator.CommonUtils.addErrorToResultsFile;
 import static org.json.JSONObject.NULL;
 
 import java.util.HashSet;
@@ -19,10 +16,7 @@ import org.json.JSONObject;
 
 public final class ResponseValidation2Dot9Dot1And2Dot9Dot2 extends HandleValidation {
 
-  public static final String NAMESERVERS_PATH = "$.nameservers[*]";
-  public static final String HANDLE_PATH = "$.handle";
   private final RDAPValidatorConfiguration config;
-  public static final String ICANNRST = "ICANNRST";
 
   public ResponseValidation2Dot9Dot1And2Dot9Dot2(RDAPValidatorConfiguration config,
       String rdapResponse,
@@ -40,95 +34,43 @@ public final class ResponseValidation2Dot9Dot1And2Dot9Dot2 extends HandleValidat
 
   @Override
   protected boolean doValidate() {
-    if (config.isGtldRegistrar()) {
-      return doValidationFor291();
-    } else {
-      // Only if the 2024 flag is checked
-      if(this.config.useRdapProfileFeb2024()) {
-        return doValidationFor292();
+    boolean isValid = true;
+    Set<String> nsWithoutStatus = new HashSet<>();
+    boolean oneWithStatus = false;
+    Set<String> nsWithoutHandle = new HashSet<>();
+    boolean oneWithHandle = false;
+    Set<String> jsonPointers = getPointerFromJPath("$.nameservers[*]");
+
+    for (String jsonPointer : jsonPointers) {
+      JSONObject nameserver = (JSONObject) jsonObject.query(jsonPointer);
+      if (NULL.equals(nameserver.opt("handle"))) {
+        nsWithoutHandle.add(jsonPointer);
       } else {
-        return false;
+        oneWithHandle = true;
       }
+      if (NULL.equals(nameserver.opt("status"))) {
+        nsWithoutStatus.add(jsonPointer);
+      } else {
+        oneWithStatus = true;
+      }
+      isValid &= checkLdhName(jsonPointer);
+      isValid &= checkHandles(jsonPointer);
+      isValid &= checkStatuses(jsonPointer);
     }
-  }
 
-  public boolean doValidationFor292() {
-    boolean isValid = true;
-    Set<String> jsonPointers = getPointerFromJPath(NAMESERVERS_PATH);
-    for (String jsonPointer : jsonPointers) {
-      isValid &= checkHandleForNameServers292(jsonPointer);
+    if ((oneWithHandle && !nsWithoutHandle.isEmpty()) || (oneWithStatus && !nsWithoutStatus
+        .isEmpty())) {
+      nsWithoutHandle.addAll(nsWithoutStatus);
+      nsWithoutHandle.forEach(jsonPointer ->
+          results.add(RDAPValidationResult.builder()
+              .code(-47203)
+              .value(getResultValue(jsonPointer))
+              .message("The handle or status in the nameserver object is not included.")
+              .build()));
+      isValid = false;
     }
 
     return isValid;
-  }
-
-  public boolean checkHandleForNameServers292(String nameserverJsonPointer) {
-    boolean isValid = true;
-    JSONObject nameserver = (JSONObject) jsonObject.query(nameserverJsonPointer);
-    Set<String> jsonPointers = getPointerFromJPath(nameserver, HANDLE_PATH);
-    for (String jsonPointer : jsonPointers) {
-      isValid &= validateHandle292(nameserverJsonPointer.concat(jsonPointer.substring(ONE)));
-    }
-    return isValid;
-  }
-
-  public boolean validateHandle292(String handleJsonPointer) {
-    String handle = null;
-    Object obj = jsonObject.query(handleJsonPointer);
-    if (obj != null) {
-      handle = obj.toString();
-    }
-
-    if (handle == null || !handle.matches("(\\w|_){1,80}-\\w{1,8}")) {
-      return false;
-    }
-
-    String endOfNameServerHandle = handle.substring(handle.indexOf(HYPHEN) + ONE);
-    if (endOfNameServerHandle.endsWith(ICANNRST) && this.queryType.equals(RDAPQueryType.DOMAIN) && this.config.useRdapProfileFeb2024()) {
-      addErrorToResultsFile(-47205, getResultValue(handleJsonPointer),
-          "The globally unique identifier in the nameserver object handle is using an EPPROID reserved for testing by ICANN.");
-    return false;
-    }
-    return true;
-  }
-
-  private boolean doValidationFor291() {
-      boolean isValid = true;
-      Set<String> nsWithoutStatus = new HashSet<>();
-      boolean oneWithStatus = false;
-      Set<String> nsWithoutHandle = new HashSet<>();
-      boolean oneWithHandle = false;
-      Set<String> jsonPointers = getPointerFromJPath(NAMESERVERS_PATH);
-
-      for (String jsonPointer : jsonPointers) {
-        JSONObject nameserver = (JSONObject) jsonObject.query(jsonPointer);
-        if (NULL.equals(nameserver.opt("handle"))) {
-          nsWithoutHandle.add(jsonPointer);
-        } else {
-          oneWithHandle = true;
-        }
-        if (NULL.equals(nameserver.opt("status"))) {
-          nsWithoutStatus.add(jsonPointer);
-        } else {
-          oneWithStatus = true;
-        }
-        isValid &= checkLdhName(jsonPointer);
-        isValid &= checkHandles(jsonPointer);
-        isValid &= checkStatuses(jsonPointer);
-      }
-
-      if ((oneWithHandle && !nsWithoutHandle.isEmpty()) || (oneWithStatus && !nsWithoutStatus.isEmpty())) {
-        nsWithoutHandle.addAll(nsWithoutStatus);
-        nsWithoutHandle.forEach(jsonPointer -> results.add(RDAPValidationResult.builder()
-                                                                               .code(-47203)
-                                                                               .value(getResultValue(jsonPointer))
-                                                                               .message(
-                                                                                   "The handle or status in the nameserver object is not included.")
-                                                                               .build()));
-        isValid = false;
-      }
-
-      return isValid;
   }
 
   private boolean checkLdhName(String nameserverJsonPointer) {
@@ -146,10 +88,11 @@ public final class ResponseValidation2Dot9Dot1And2Dot9Dot2 extends HandleValidat
 
   private boolean checkHandles(String nameserverJsonPointer) {
     boolean isValid = true;
+
     JSONObject nameserver = (JSONObject) jsonObject.query(nameserverJsonPointer);
-    Set<String> jsonPointers = getPointerFromJPath(nameserver, HANDLE_PATH);
+    Set<String> jsonPointers = getPointerFromJPath(nameserver, "$.handle");
     for (String jsonPointer : jsonPointers) {
-      isValid &= validateHandle(nameserverJsonPointer.concat(jsonPointer.substring(ONE)));
+      isValid &= validateHandle(nameserverJsonPointer.concat(jsonPointer.substring(1)));
     }
     return isValid;
   }
@@ -191,6 +134,6 @@ public final class ResponseValidation2Dot9Dot1And2Dot9Dot2 extends HandleValidat
 
   @Override
   public boolean doLaunch() {
-     return  queryType.equals(RDAPQueryType.DOMAIN);
+     return config.isGtldRegistrar() && queryType.equals(RDAPQueryType.DOMAIN);
   }
 }

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/ResponseValidation2Dot9Dot1And2Dot9Dot2_2024.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/ResponseValidation2Dot9Dot1And2Dot9Dot2_2024.java
@@ -1,0 +1,81 @@
+package org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain;
+
+import static org.icann.rdapconformance.validator.CommonUtils.ONE;
+
+import java.util.Set;
+import org.icann.rdapconformance.validator.workflow.profile.ProfileJsonValidation;
+import org.icann.rdapconformance.validator.workflow.rdap.RDAPQueryType;
+import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidationResult;
+import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidatorResults;
+import org.json.JSONObject;
+
+
+public final class ResponseValidation2Dot9Dot1And2Dot9Dot2_2024 extends ProfileJsonValidation {
+
+    public static final String NAMESERVERS_PATH = "$.nameservers[*]";
+    public static final String HANDLE_PATH = "$.handle";
+
+    private final RDAPQueryType queryType;
+
+    public ResponseValidation2Dot9Dot1And2Dot9Dot2_2024(String rdapResponse, RDAPValidatorResults results, RDAPQueryType queryType) {
+        super(rdapResponse, results);
+
+        this.queryType = queryType;
+    }
+
+    @Override
+    public String getGroupName() {
+        return "rdapResponseProfile_2_9_1_and_2_9_2_Validation";
+    }
+
+    @Override
+    protected boolean doValidate() {
+        boolean isValid = true;
+        Set<String> jsonPointers = getPointerFromJPath(NAMESERVERS_PATH);
+        for (String jsonPointer : jsonPointers) {
+            isValid &= checkHandleForNameServers(jsonPointer);
+        }
+
+        return isValid;
+    }
+
+    public boolean checkHandleForNameServers(String nameserverJsonPointer) {
+        boolean isValid = true;
+        JSONObject nameserver = (JSONObject) jsonObject.query(nameserverJsonPointer);
+        Set<String> jsonPointers = getPointerFromJPath(nameserver, HANDLE_PATH);
+        for (String jsonPointer : jsonPointers) {
+            isValid &= validateHandle(nameserverJsonPointer.concat(jsonPointer.substring(ONE)));
+        }
+        return isValid;
+    }
+
+    public boolean validateHandle(String handleJsonPointer) {
+        String handle = "";
+        Object obj = jsonObject.query(handleJsonPointer);
+        if (obj != null) {
+            // have to use .toString() instead of cast (String),
+            // because if the value is JSONObject.NULL, it won't cast
+            // added testValidate_HandleIsNull_AddErrorCode unit test for this
+            handle = obj.toString();
+        }
+
+        if (handle != null && handle.endsWith("-ICANNRST")) {
+            results.add(RDAPValidationResult.builder()
+                .code(-47205)
+                .value(getResultValue(handleJsonPointer))
+                .message(
+                    "The globally unique identifier in the domain object handle is using an EPPROID reserved for testing by ICANN.")
+                .build());
+
+            return false;
+        }
+
+        return true;
+    }
+
+
+    @Override
+    public boolean doLaunch() {
+        return queryType.equals(RDAPQueryType.DOMAIN);
+    }
+}

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/entities/ResponseValidation2Dot7Dot1DotXAndRelated3And4_2024.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/entities/ResponseValidation2Dot7Dot1DotXAndRelated3And4_2024.java
@@ -1,0 +1,62 @@
+package org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain.entities;
+
+import java.util.Set;
+import org.icann.rdapconformance.validator.configuration.RDAPValidatorConfiguration;
+import org.icann.rdapconformance.validator.workflow.rdap.RDAPQueryType;
+import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidationResult;
+import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidatorResults;
+import org.json.JSONObject;
+
+/**
+ * 8.8.1.3 & 8.8.1.4
+ */
+public class ResponseValidation2Dot7Dot1DotXAndRelated3And4_2024 extends
+    ResponseValidation2Dot7Dot1DotXAndRelated {
+
+    public ResponseValidation2Dot7Dot1DotXAndRelated3And4_2024(String rdapResponse,
+        RDAPValidatorResults results,
+        RDAPQueryType queryType,
+        RDAPValidatorConfiguration config) {
+        super(rdapResponse, results, queryType, config);
+    }
+
+    @Override
+    protected boolean doValidateEntity(String jsonPointer, JSONObject entity) {
+        if (isChildOfRegistrar(jsonPointer)) {
+            return true;
+        }
+
+        Set<String> withRemarkTitleRedactedForPrivacy =
+            getPointerFromJPath(entity, "$.remarks[?(@.title == 'REDACTED FOR PRIVACY')]");
+
+        if (withRemarkTitleRedactedForPrivacy.isEmpty()) {
+            return this.validateHandle(jsonPointer + "/handle");
+        }
+
+        return true;
+    }
+
+    private boolean validateHandle(String handleJsonPointer) {
+        String handle = "";
+
+        Object obj = jsonObject.query(handleJsonPointer);
+        if (obj != null) {
+            // have to use .toString() instead of cast (String),
+            // because if the value is JSONObject.NULL, it won't cast
+            // added testValidate_HandleIsNull_AddErrorCode unit test for this
+            handle = obj.toString();
+        }
+
+        if (handle != null && handle.endsWith("-ICANNRST")) {
+            results.add(RDAPValidationResult.builder()
+                .code(-52106)
+                .value(getResultValue(handleJsonPointer))
+                .message(
+                    "The globally unique identifier in the entity object handle is using an EPPROID reserved for testing by ICANN.")
+                .build());
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/nameserver/ResponseValidation4Dot1Handle_2024.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/nameserver/ResponseValidation4Dot1Handle_2024.java
@@ -1,0 +1,52 @@
+package org.icann.rdapconformance.validator.workflow.profile.rdap_response.nameserver;
+
+import org.icann.rdapconformance.validator.workflow.profile.ProfileJsonValidation;
+import org.icann.rdapconformance.validator.workflow.rdap.RDAPQueryType;
+import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidationResult;
+import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidatorResults;
+
+public final class ResponseValidation4Dot1Handle_2024 extends ProfileJsonValidation {
+    private final RDAPQueryType queryType;
+
+    public ResponseValidation4Dot1Handle_2024(String rdapResponse, RDAPValidatorResults results, RDAPQueryType queryType) {
+        super(rdapResponse, results);
+
+        this.queryType = queryType;
+    }
+
+    @Override
+    public String getGroupName() {
+        return "rdapResponseProfile_4_1_Validation";
+    }
+
+    @Override
+    protected boolean doValidate() {
+        String handle = "";
+
+        Object obj = jsonObject.query("#/handle");
+        if (obj != null) {
+            // have to use .toString() instead of cast (String),
+            // because if the value is JSONObject.NULL, it won't cast
+            // added testValidate_HandleIsNull_AddErrorCode unit test for this
+            handle = obj.toString();
+        }
+
+        if (handle != null && handle.endsWith("-ICANNRST")) {
+            results.add(RDAPValidationResult.builder()
+                .code(-49104)
+                .value(getResultValue("#/handle"))
+                .message(
+                    "The globally unique identifier in the nameserver object handle is using an EPPROID reserved for testing by ICANN.")
+                .build());
+
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean doLaunch() {
+        return queryType.equals(RDAPQueryType.NAMESERVER);
+    }
+}

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidator.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidator.java
@@ -10,7 +10,11 @@ import java.util.Map;
 import org.icann.rdapconformance.validator.ConformanceError;
 import org.icann.rdapconformance.validator.NetworkInfo;
 import org.icann.rdapconformance.validator.ToolResult;
+import org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain.ResponseValidation2Dot2_2024;
+import org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain.ResponseValidation2Dot9Dot1And2Dot9Dot2_2024;
+import org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain.entities.ResponseValidation2Dot7Dot1DotXAndRelated3And4_2024;
 import org.icann.rdapconformance.validator.workflow.profile.rdap_response.general.*;
+import org.icann.rdapconformance.validator.workflow.profile.rdap_response.nameserver.ResponseValidation4Dot1Handle_2024;
 import org.icann.rdapconformance.validator.workflow.profile.tig_section.general.TigValidation1Dot5_2024;
 import org.icann.rdapconformance.validator.workflow.profile.tig_section.general.TigValidation3Dot3And3Dot4_2024;
 import org.icann.rdapconformance.validator.workflow.profile.tig_section.registry.TigValidation3Dot2_2024;
@@ -264,6 +268,10 @@ public class RDAPValidator implements ValidatorWorkflow {
         validations.add(new TigValidation1Dot3_2024(query.getData(), results)); // clean
         validations.add(new ResponseValidation1Dot2_1_2024(query.getData(), results)); // clean
         validations.add(new ResponseValidation1Dot2_2_2024(query.getData(), results)); // clean
+        validations.add(new ResponseValidation2Dot2_2024(query.getData(), results, queryTypeProcessor.getQueryType())); // clean
+        validations.add(new ResponseValidation2Dot7Dot1DotXAndRelated3And4_2024(query.getData(), results, queryTypeProcessor.getQueryType(), config)); // clean
+        validations.add(new ResponseValidation2Dot9Dot1And2Dot9Dot2_2024(query.getData(), results, queryTypeProcessor.getQueryType())); // clean
+        validations.add(new ResponseValidation4Dot1Handle_2024(query.getData(), results, queryTypeProcessor.getQueryType())); // clean
         validations.add(new ResponseValidationLinkElements_2024(query.getData(), results)); // clean
         validations.add(new ResponseValidationStatusDuplication_2024(query.getData(), results)); // clean
         validations.add(new StdRdapConformanceValidation_2024(query.getData(), results)); // clean

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/ResponseValidation2Dot2Test.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/ResponseValidation2Dot2Test.java
@@ -60,31 +60,4 @@ public class ResponseValidation2Dot2Test extends HandleValidationTest<ResponseVa
         "The handle in the entity object does not comply with the format "
             + "(\\w|_){1,80}-\\w{1,8} specified in RFC5730.");
   }
-
-  // this is a problem, you cannot run it like the others above
-  @Test
-  public void testValidate_HandleIsInvalid_AddErrorCode() {
-    // Store the original configuration
-    RDAPValidatorConfiguration originalConfig = config;
-
-    try {
-      // Create a mock configuration using SPY instead of mock
-      RDAPValidatorConfiguration mockConfig = Mockito.spy(originalConfig);
-
-      // SUPER important ->  override this method
-      when(mockConfig.useRdapProfileFeb2024()).thenReturn(true);
-
-      // Replace the config with our mock
-      this.config = mockConfig;
-
-      // Run the test with our mocked configuration
-      String value = givenReservedICANNHandle();
-      getProfileValidation();
-      validate(-46205, value,
-          "The globally unique identifier in the domain object handle is using an EPPROID reserved for testing by ICANN.");
-    } finally {
-      // Restore the original configuration
-      this.config = originalConfig;
-    }
-  }
 }

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/ResponseValidation2Dot2_2024Test.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/ResponseValidation2Dot2_2024Test.java
@@ -1,0 +1,32 @@
+package org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain;
+
+import org.icann.rdapconformance.validator.workflow.profile.ProfileJsonValidationTestBase;
+import org.icann.rdapconformance.validator.workflow.profile.ProfileValidation;
+import org.icann.rdapconformance.validator.workflow.rdap.RDAPQueryType;
+import org.testng.annotations.Test;
+
+
+public class ResponseValidation2Dot2_2024Test extends ProfileJsonValidationTestBase {
+
+    public ResponseValidation2Dot2_2024Test() {
+        super("/validators/domain/valid.json", "rdapResponseProfile_2_1_Validation");
+    }
+
+    @Override
+    public ProfileValidation getProfileValidation() {
+        return new ResponseValidation2Dot2_2024(jsonObject.toString(), results, RDAPQueryType.DOMAIN);
+    }
+
+    protected String givenReservedICANNHandle() {
+        replaceValue("handle", "12345678-ICANNRST");
+        return "#/handle:12345678-ICANNRST";
+    }
+
+    @Test
+    public void testValidate_HandleIsInvalid_AddErrorCode() {
+            String value = givenReservedICANNHandle();
+            getProfileValidation();
+            validate(-46205, value,
+                "The globally unique identifier in the domain object handle is using an EPPROID reserved for testing by ICANN.");
+    }
+}

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/ResponseValidation2Dot9Dot1And2Dot9Dot2Test.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/ResponseValidation2Dot9Dot1And2Dot9Dot2Test.java
@@ -6,14 +6,10 @@ import java.util.Set;
 import org.icann.rdapconformance.validator.configuration.RDAPValidatorConfiguration;
 import org.icann.rdapconformance.validator.workflow.profile.rdap_response.HandleValidationTest;
 import org.icann.rdapconformance.validator.workflow.rdap.RDAPQueryType;
-import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidationResult;
-import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidatorResults;
-import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidatorResultsImpl;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
@@ -94,142 +90,5 @@ public class ResponseValidation2Dot9Dot1And2Dot9Dot2Test extends
     validate(-47204,
         "#/nameservers/0/status:[\"" + String.join("\",\"", status) + "\"]",
         "The values of the status data structure does not comply with RFC5732.");
-  }
-
-  @Test
-  public void testDoValidationFor292_ReturnsTrue() throws Exception {
-    // Setup
-    RDAPValidatorResults results = RDAPValidatorResultsImpl.getInstance();
-    results.clear();
-
-    String validJson = "{\"nameservers\":[" +
-        "{\"objectClassName\":\"nameserver\",\"handle\":\"ABC123-EXAMPLE\",\"ldhName\":\"ns1.example.com\"}," +
-        "{\"objectClassName\":\"nameserver\",\"handle\":\"DEF456-EXAMPLE\",\"ldhName\":\"ns2.example.com\"}" +
-        "]}";
-
-    RDAPValidatorConfiguration config = mock(RDAPValidatorConfiguration.class);
-    doReturn(false).when(config).isGtldRegistrar();
-    doReturn(true).when(config).useRdapProfileFeb2024();
-
-    ResponseValidation2Dot9Dot1And2Dot9Dot2 validation = new ResponseValidation2Dot9Dot1And2Dot9Dot2(
-        config, validJson, results, null, RDAPQueryType.DOMAIN);
-
-    boolean result = validation.doValidationFor292();
-    assertThat(result).isTrue();
-    assertThat(results.getAll()).isEmpty();
-  }
-
-  @Test
-  public void testDoValidationFor292_InvalidHandleFormat_ReturnsFalse() throws Exception {
-    RDAPValidatorResults results = RDAPValidatorResultsImpl.getInstance();
-    results.clear();
-
-    String invalidJson = "{\"nameservers\":[" +
-        "{\"objectClassName\":\"nameserver\",\"handle\":\"INVALID-HANDLE-WITH-NO-PROPER-FORMAT\",\"ldhName\":\"ns1.example.com\"}," +
-        "{\"objectClassName\":\"nameserver\",\"handle\":\"DEF456-EXAMPLE\",\"ldhName\":\"ns2.example.com\"}" +
-        "]}";
-
-    RDAPValidatorConfiguration config = mock(RDAPValidatorConfiguration.class);
-    doReturn(false).when(config).isGtldRegistrar();
-    doReturn(true).when(config).useRdapProfileFeb2024();
-
-    ResponseValidation2Dot9Dot1And2Dot9Dot2 validation = new ResponseValidation2Dot9Dot1And2Dot9Dot2(
-        config, invalidJson, results, null, RDAPQueryType.DOMAIN);
-
-    boolean result = validation.doValidationFor292();
-    assertThat(result).isFalse();
-  }
-
-  @Test
-  public void testDoValidationFor292_IcannRstHandle_ReturnsFalse() throws Exception {
-    // Setup
-    RDAPValidatorResults results = RDAPValidatorResultsImpl.getInstance();
-    results.clear();
-
-    String invalidJson = "{\"nameservers\":[" +
-        "{\"objectClassName\":\"nameserver\",\"handle\":\"ABC123-ICANNRST\",\"ldhName\":\"ns1.example.com\"}," +
-        "{\"objectClassName\":\"nameserver\",\"handle\":\"DEF456-EXAMPLE\",\"ldhName\":\"ns2.example.com\"}" +
-        "]}";
-
-    RDAPValidatorConfiguration config = mock(RDAPValidatorConfiguration.class);
-    doReturn(false).when(config).isGtldRegistrar();
-    doReturn(true).when(config).useRdapProfileFeb2024();
-
-    ResponseValidation2Dot9Dot1And2Dot9Dot2 validation = new ResponseValidation2Dot9Dot1And2Dot9Dot2(
-        config, invalidJson, results, null, RDAPQueryType.DOMAIN);
-
-    boolean result = validation.doValidationFor292();
-    assertThat(result).isFalse();
-    assertThat(results.getAll()).contains(
-        RDAPValidationResult.builder()
-                            .code(-47205)
-                            .value("#/nameservers/0/handle:ABC123-ICANNRST")
-                            .message("The globally unique identifier in the nameserver object handle is using an EPPROID reserved for testing by ICANN.")
-                            .build());
-  }
-
-  @Test
-  public void testDoValidationFor292_MissingHandle_ReturnsFalse() throws Exception {
-    // Setup
-    RDAPValidatorResults results = RDAPValidatorResultsImpl.getInstance();
-    results.clear();
-
-    String invalidJson = "{\"nameservers\":[" +
-        "{\"objectClassName\":\"nameserver\",\"ldhName\":\"ns1.example.com\"}," +
-        "{\"objectClassName\":\"nameserver\",\"handle\":\"DEF456-EXAMPLE\",\"ldhName\":\"ns2.example.com\"}" +
-        "]}";
-
-    RDAPValidatorConfiguration config = mock(RDAPValidatorConfiguration.class);
-    doReturn(false).when(config).isGtldRegistrar();
-    doReturn(true).when(config).useRdapProfileFeb2024();
-
-    ResponseValidation2Dot9Dot1And2Dot9Dot2 validation = new ResponseValidation2Dot9Dot1And2Dot9Dot2(
-        config, invalidJson, results, null, RDAPQueryType.DOMAIN);
-
-    boolean result = validation.doValidationFor292();
-    assertThat(result).isTrue(); // No validation result for missing handle in this code path
-  }
-
-  @Test
-  public void testDoValidationFor292_IcannRstHandleWithFeb2024ProfileDisabled_ReturnsTrue() throws Exception {
-    RDAPValidatorResults results = RDAPValidatorResultsImpl.getInstance();
-    results.clear();
-
-    String invalidJson = "{\"nameservers\":[" +
-        "{\"objectClassName\":\"nameserver\",\"handle\":\"ABC123-ICANNRST\",\"ldhName\":\"ns1.example.com\"}," +
-        "{\"objectClassName\":\"nameserver\",\"handle\":\"DEF456-EXAMPLE\",\"ldhName\":\"ns2.example.com\"}" +
-        "]}";
-
-    RDAPValidatorConfiguration config = mock(RDAPValidatorConfiguration.class);
-    doReturn(false).when(config).isGtldRegistrar();
-    doReturn(false).when(config).useRdapProfileFeb2024(); // Feb 2024 profile disabled
-
-    ResponseValidation2Dot9Dot1And2Dot9Dot2 validation = new ResponseValidation2Dot9Dot1And2Dot9Dot2(
-        config, invalidJson, results, null, RDAPQueryType.DOMAIN);
-
-    boolean result = validation.doValidationFor292();
-    assertThat(result).isTrue();
-    assertThat(results.getAll()).isEmpty();
-  }
-
-  @Test
-  public void testDoValidationFor292_ReturnsFalse() throws Exception {
-    RDAPValidatorResults results = RDAPValidatorResultsImpl.getInstance();
-    results.clear();
-
-    String invalidJson = "{\"nameservers\":[" +
-        "{\"objectClassName\":\"nameserver\",\"handle\":\"INVALID-HANDLE!\",\"ldhName\":\"ns1.example.com\"}," +
-        "{\"objectClassName\":\"nameserver\",\"handle\":\"ALSO@INVALID\",\"ldhName\":\"ns2.example.com\"}" +
-        "]}";
-
-    RDAPValidatorConfiguration config = mock(RDAPValidatorConfiguration.class);
-    doReturn(false).when(config).isGtldRegistrar();
-    doReturn(true).when(config).useRdapProfileFeb2024();
-
-    ResponseValidation2Dot9Dot1And2Dot9Dot2 validation = new ResponseValidation2Dot9Dot1And2Dot9Dot2(
-        config, invalidJson, results, null, RDAPQueryType.DOMAIN);
-    boolean result = validation.doValidationFor292();
-
-    assertThat(result).isFalse();
   }
 }

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/ResponseValidation2Dot9Dot1And2Dot9Dot2_2024Test.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/ResponseValidation2Dot9Dot1And2Dot9Dot2_2024Test.java
@@ -1,0 +1,27 @@
+package org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain;
+
+import org.icann.rdapconformance.validator.workflow.profile.ProfileJsonValidationTestBase;
+import org.icann.rdapconformance.validator.workflow.profile.ProfileValidation;
+import org.icann.rdapconformance.validator.workflow.rdap.RDAPQueryType;
+import org.testng.annotations.Test;
+
+
+public class ResponseValidation2Dot9Dot1And2Dot9Dot2_2024Test extends ProfileJsonValidationTestBase {
+
+    public ResponseValidation2Dot9Dot1And2Dot9Dot2_2024Test() {
+        super("/validators/domain/valid.json", "rdapResponseProfile_2_9_1_and_2_9_2_Validation");
+    }
+
+    @Override
+    public ProfileValidation getProfileValidation() {
+        return new ResponseValidation2Dot9Dot1And2Dot9Dot2_2024(jsonObject.toString(), results, RDAPQueryType.DOMAIN);
+    }
+
+    @Test
+    public void testDoValidationFor292_IcannRstHandle_ReturnsFalse() throws Exception {
+        replaceValue("$['nameservers'][0]['handle']", "2138514_DOMAIN_COM-ICANNRST");
+
+        validate(-47205, "#/nameservers/0/handle:2138514_DOMAIN_COM-ICANNRST",
+            "The globally unique identifier in the domain object handle is using an EPPROID reserved for testing by ICANN.");
+    }
+}

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/entities/ResponseValidation2Dot7Dot1DotXAndRelated3And4_2024Test.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/entities/ResponseValidation2Dot7Dot1DotXAndRelated3And4_2024Test.java
@@ -1,0 +1,31 @@
+package org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain.entities;
+
+import java.io.IOException;
+import org.icann.rdapconformance.validator.workflow.profile.ProfileValidation;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class ResponseValidation2Dot7Dot1DotXAndRelated3And4_2024Test extends
+    ResponseValidation2Dot7Dot1DotXAndRelatedTest {
+
+    @Override
+    @BeforeMethod
+    public void setUp() throws IOException {
+        super.setUp();
+        replaceValue("['entities'][0]['handle']", "2138514_DOMAIN_COM-EXMP");
+    }
+
+    @Override
+    public ProfileValidation getProfileValidation() {
+        return new ResponseValidation2Dot7Dot1DotXAndRelated3And4_2024(jsonObject.toString(), results,
+            queryType, config);
+    }
+
+    @Test
+    public void testValidate_HandleIsInvalid_AddErrorCode() {
+        entitiesWithRole("registrant");
+        replaceValue("['entities'][0]['handle']", "2138514_DOMAIN_COM-ICANNRST");
+        validate(-52106, "#/entities/0/handle:2138514_DOMAIN_COM-ICANNRST",
+            "The globally unique identifier in the entity object handle is using an EPPROID reserved for testing by ICANN.");
+    }
+}

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/nameserver/ResponseValidation4Dot1HandleTest.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/nameserver/ResponseValidation4Dot1HandleTest.java
@@ -31,30 +31,4 @@ public class ResponseValidation4Dot1HandleTest extends
   protected String getValidValueWithRoidExmp() {
     return "#/handle:2138514_NS_COM-EXMP";
   }
-
-  @Test
-  public void testValidate_HandleIsInvalid_AddErrorCode() {
-    // Store the original configuration
-    RDAPValidatorConfiguration originalConfig = config;
-
-    try {
-      // Create a mock configuration using SPY instead of mock
-      RDAPValidatorConfiguration mockConfig = Mockito.spy(originalConfig);
-
-      // Override the method we need
-      when(mockConfig.useRdapProfileFeb2024()).thenReturn(true);
-
-      // Replace the config with our mock
-      this.config = mockConfig;
-
-      // Run the test with our mocked configuration
-      String value = givenReservedICANNHandle();
-      getProfileValidation();
-      validate(-49104, value,
-          "The globally unique identifier in the nameserver object handle is using an EPPROID reserved for testing by ICANN.");
-    } finally {
-      // Restore the original configuration
-      this.config = originalConfig;
-    }
-  }
 }

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/nameserver/ResponseValidation4Dot1Handle_2024Test.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/nameserver/ResponseValidation4Dot1Handle_2024Test.java
@@ -1,0 +1,32 @@
+package org.icann.rdapconformance.validator.workflow.profile.rdap_response.nameserver;
+
+import org.icann.rdapconformance.validator.workflow.profile.ProfileJsonValidationTestBase;
+import org.icann.rdapconformance.validator.workflow.profile.ProfileValidation;
+import org.icann.rdapconformance.validator.workflow.rdap.RDAPQueryType;
+import org.testng.annotations.Test;
+
+public class ResponseValidation4Dot1Handle_2024Test extends ProfileJsonValidationTestBase {
+
+    public ResponseValidation4Dot1Handle_2024Test() {
+        super("/validators/nameserver/valid.json", "rdapResponseProfile_4_1_Validation");
+    }
+
+    @Override
+    public ProfileValidation getProfileValidation() {
+        return new ResponseValidation4Dot1Handle_2024(jsonObject.toString(), results, RDAPQueryType.NAMESERVER);
+    }
+
+    protected String givenReservedICANNHandle() {
+        replaceValue("handle", "ABCD-ICANNRST");
+        return "#/handle:ABCD-ICANNRST";
+    }
+
+
+    @Test
+    public void testValidate_HandleIsInvalid_AddErrorCode() {
+        String value = givenReservedICANNHandle();
+        getProfileValidation();
+        validate(-49104, value,
+            "The globally unique identifier in the nameserver object handle is using an EPPROID reserved for testing by ICANN.");
+    }
+}


### PR DESCRIPTION
feat/RCT-150, 151, 152 and 153: handle validation, not ending with ICANNRST.

1. moved the logic previously added to the HandleValidation.class to the two dedicated "2024" classes: ResponseValidation2Dot2_2024 and ResponseValidation4Dot1Handle_2024.class
2. moved the logic previously added to the ResponseValidation2Dot9Dot1And2Dot9Dot2.class to the dedicated new ResponseValidation2Dot9Dot1And2Dot9Dot2_2024.class
3. added logic to the new ResponseValidation2Dot7Dot1DotXAndRelated3And4_2024.class

https://icann-jira.atlassian.net/browse/RCT-150
https://icann-jira.atlassian.net/browse/RCT-151
https://icann-jira.atlassian.net/browse/RCT-152
https://icann-jira.atlassian.net/browse/RCT-153