### PR TITLE
bug/RCT-195-FailedConnectionError

### DIFF
--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/tig_section/general/TigValidation1Dot2.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/tig_section/general/TigValidation1Dot2.java
@@ -67,7 +67,7 @@ public final class TigValidation1Dot2 extends ProfileValidation {
     if (rdapResponse.uri().getScheme().equals(HTTPS)) {
       try {
         URI uri = URI.create(rdapResponse.uri().toString().replaceFirst(HTTPS_PREFIX, HTTP_PREFIX));
-        // makeRequest(URI originalUri, int timeoutSeconds, String method, boolean isMain, boolean canThrowError)
+        // the two false items are: it is not the main connection and do not record an error if the http connection fails - that's a good thing that it fails!
         HttpResponse<String> httpResponse = RDAPHttpRequest.makeRequest(uri, config.getTimeout(), GET, false, false);
         JsonNode httpResponseJson = mapper.readTree(httpResponse.body());
         JsonNode httpsResponseJson = mapper.readTree(rdapResponse.body());

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/tig_section/general/TigValidation1Dot2.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/tig_section/general/TigValidation1Dot2.java
@@ -67,13 +67,14 @@ public final class TigValidation1Dot2 extends ProfileValidation {
     if (rdapResponse.uri().getScheme().equals(HTTPS)) {
       try {
         URI uri = URI.create(rdapResponse.uri().toString().replaceFirst(HTTPS_PREFIX, HTTP_PREFIX));
-        HttpResponse<String> httpResponse = RDAPHttpRequest.makeHttpGetRequest(uri, config.getTimeout());
+        // makeRequest(URI originalUri, int timeoutSeconds, String method, boolean isMain, boolean canThrowError)
+        HttpResponse<String> httpResponse = RDAPHttpRequest.makeRequest(uri, config.getTimeout(), GET, false, false);
         JsonNode httpResponseJson = mapper.readTree(httpResponse.body());
         JsonNode httpsResponseJson = mapper.readTree(rdapResponse.body());
         if (!httpResponse.uri().getScheme().equals(HTTPS) // if redirect to https, do not validate
             && jsonComparator.compare(httpResponseJson,
             httpsResponseJson) == 0) {
-          results.add(RDAPValidationResult.builder()
+            results.add(RDAPValidationResult.builder()
                                           .queriedURI(httpResponse.uri().toString())
                                           .httpMethod(GET)
                                           .httpStatusCode(httpResponse.statusCode())

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
@@ -3,13 +3,10 @@ package org.icann.rdapconformance.validator.workflow.rdap.http;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import java.io.IOException;
-import java.net.ConnectException;
 import java.net.URI;
-import java.net.UnknownHostException;
 import java.net.http.HttpHeaders;
 import java.net.http.HttpResponse;
-import java.net.http.HttpTimeoutException;
+
 import java.security.Security;
 import java.util.*;
 import org.icann.rdapconformance.validator.ConformanceError;

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQueryTest.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQueryTest.java
@@ -245,7 +245,7 @@ public class RDAPHttpQueryTest extends HttpTestingUtils {
     assertThat(results.getAll()).contains(
         RDAPValidationResult.builder()
                             .code(-13017)
-                            .httpStatusCode(0)
+                            .httpStatusCode(ZERO)
                             .value("no response available")
                             .message("Network receive fail")
                             .build());

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQueryTest.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQueryTest.java
@@ -23,6 +23,7 @@ import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.icann.rdapconformance.validator.ConnectionStatus;
 
+import static org.icann.rdapconformance.validator.CommonUtils.ZERO;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -196,6 +197,7 @@ public class RDAPHttpQueryTest extends HttpTestingUtils {
         expectedStatus = ConnectionStatus.CONNECTION_FAILED;
         expectedResult = RDAPValidationResult.builder()
                                              .code(-13007)
+                                             .httpStatusCode(ZERO)
                                              .value("no response available")
                                              .message("Failed to connect to server.")
                                              .build();
@@ -204,6 +206,7 @@ public class RDAPHttpQueryTest extends HttpTestingUtils {
         expectedStatus = ConnectionStatus.NETWORK_RECEIVE_FAIL;
         expectedResult = RDAPValidationResult.builder()
                                              .code(-13017)
+                                             .httpStatusCode(ZERO)
                                              .value("no response available")
                                              .message("Network receive fail")
                                              .build();
@@ -212,6 +215,7 @@ public class RDAPHttpQueryTest extends HttpTestingUtils {
         expectedStatus = ConnectionStatus.NETWORK_RECEIVE_FAIL;
         expectedResult = RDAPValidationResult.builder()
                                              .code(-13017)
+                                             .httpStatusCode(ZERO)
                                              .value("no response available")
                                              .message("Network receive fail")
                                              .build();
@@ -241,6 +245,7 @@ public class RDAPHttpQueryTest extends HttpTestingUtils {
     assertThat(results.getAll()).contains(
         RDAPValidationResult.builder()
                             .code(-13017)
+                            .httpStatusCode(0)
                             .value("no response available")
                             .message("Network receive fail")
                             .build());
@@ -843,54 +848,6 @@ public class RDAPHttpQueryTest extends HttpTestingUtils {
       rdapHttpQuery.run();
       List<URI> redirects = rdapHttpQuery.getRedirects();
       assertThat(redirects).containsExactly(uri2, uri3);
-    }
-  }
-
-  @Test
-  public void test_HandleRequestException_ClientExecuteThrowsConnectionException() throws Exception {
-    RDAPValidatorResults results = RDAPValidatorResultsImpl.getInstance();
-    results.clear();
-    rdapHttpQuery.setResults(results);
-
-    doReturn(URI.create(HTTP_TEST_EXAMPLE)).when(config).getUri();
-
-    try (MockedStatic<RDAPHttpRequest> mockedStatic = mockStatic(RDAPHttpRequest.class);
-        MockedStatic<DNSCacheResolver> dnsResolverMock = mockStatic(DNSCacheResolver.class)) {
-
-      dnsResolverMock.when(() -> DNSCacheResolver.hasNoAddresses(any(String.class)))
-                     .thenReturn(false);
-      InetAddress mockAddress = InetAddress.getByName("127.0.0.1");
-      dnsResolverMock.when(() -> DNSCacheResolver.getFirstV4Address(any(String.class)))
-                     .thenReturn(mockAddress);
-
-      ConnectException connectException = new ConnectException("Connection refused");
-      mockedStatic.when(() -> RDAPHttpRequest.executeRequest(any(CloseableHttpClient.class), any(HttpUriRequestBase.class)))
-                  .thenThrow(connectException);
-
-      // Allow the real stuff to be called
-      mockedStatic.when(() -> RDAPHttpRequest.makeRequest(any(URI.class), anyInt(), eq("GET"), eq(true)))
-                  .thenCallRealMethod();
-      mockedStatic.when(() -> RDAPHttpRequest.handleRequestException(any()))
-                     .thenCallRealMethod();
-      mockedStatic.when(() -> RDAPHttpRequest.hasCause(any(), any()))
-                     .thenCallRealMethod();
-
-
-      // Also allow makeHttpGetRequest to call through to the real method
-      mockedStatic.when(() -> RDAPHttpRequest.makeHttpGetRequest(any(URI.class), anyInt()))
-                  .thenCallRealMethod();
-
-      boolean result = rdapHttpQuery.run();
-      assertThat(result).isFalse();
-
-      assertThat(rdapHttpQuery.getErrorStatus()).isEqualTo(ConnectionStatus.CONNECTION_FAILED);
-
-      assertThat(results.getAll()).contains(
-          RDAPValidationResult.builder()
-                              .code(-13007)
-                              .value("no response available")
-                              .message("Failed to connect to server.")
-                              .build());
     }
   }
 

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpRequestTest.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpRequestTest.java
@@ -11,25 +11,38 @@ import java.net.http.HttpResponse;
 import java.security.cert.CertificateExpiredException;
 import javax.net.ssl.SSLHandshakeException;
 
+import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.Header;
 
+import org.icann.rdapconformance.validator.CommonUtils;
 import org.icann.rdapconformance.validator.ConnectionStatus;
+import org.icann.rdapconformance.validator.ConnectionTracker;
 import org.icann.rdapconformance.validator.DNSCacheResolver;
+import org.icann.rdapconformance.validator.NetworkInfo;
+import org.icann.rdapconformance.validator.NetworkProtocol;
+import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidatorResultsImpl;
 
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.icann.rdapconformance.validator.CommonUtils.EMPTY_STRING;
 import static org.icann.rdapconformance.validator.CommonUtils.GET;
 import static org.icann.rdapconformance.validator.CommonUtils.HTTP_TOO_MANY_REQUESTS;
 import static org.icann.rdapconformance.validator.CommonUtils.LOCAL_IPv4;
+import static org.icann.rdapconformance.validator.CommonUtils.ONE;
 import static org.icann.rdapconformance.validator.CommonUtils.ZERO;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
+import static org.testng.Assert.assertThrows;
 
 public class RDAPHttpRequestTest {
 
@@ -57,14 +70,17 @@ public class RDAPHttpRequestTest {
                            .thenCallRealMethod();
             httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(URI.class), anyInt(), anyString(), anyBoolean()))
                            .thenCallRealMethod();
-            httpRequestMock.when(() -> RDAPHttpRequest.handleRequestException(any()))
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(URI.class), anyInt(), anyString(), anyBoolean(), anyBoolean()))
+                           .thenCallRealMethod();
+            httpRequestMock.when(() -> RDAPHttpRequest.handleRequestException(any(), anyBoolean()))
                            .thenCallRealMethod();
 
-            HttpResponse<String> response = RDAPHttpRequest.makeRequest(testUri, timeout, "GET");
+            HttpResponse<String> response = RDAPHttpRequest.makeRequest(testUri, timeout, "GET", true);
             assertThat(((RDAPHttpRequest.SimpleHttpResponse)response).getConnectionStatusCode())
                 .isEqualTo(ConnectionStatus.UNKNOWN_HOST);
         }
     }
+
 
     @Test
     public void testMakeRequest_ConnectionClosedByPeer() throws Exception {
@@ -78,11 +94,14 @@ public class RDAPHttpRequestTest {
             httpRequestMock.when(() -> RDAPHttpRequest.executeRequest(any(), any()))
                            .thenThrow(new IOException("Connection closed by peer"));
 
+            // Add all versions of makeRequest
             httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(URI.class), anyInt(), anyString()))
                            .thenCallRealMethod();
             httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(URI.class), anyInt(), anyString(), anyBoolean()))
                            .thenCallRealMethod();
-            httpRequestMock.when(() -> RDAPHttpRequest.handleRequestException(any()))
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(URI.class), anyInt(), anyString(), anyBoolean(), anyBoolean()))
+                           .thenCallRealMethod();
+            httpRequestMock.when(() -> RDAPHttpRequest.handleRequestException(any(), anyBoolean()))
                            .thenCallRealMethod();
 
             HttpResponse<String> response = RDAPHttpRequest.makeRequest(testUri, timeout, "GET");
@@ -103,10 +122,14 @@ public class RDAPHttpRequestTest {
             httpRequestMock.when(() -> RDAPHttpRequest.executeRequest(any(), any()))
                            .thenThrow(new ConnectException("Connection refused"));
 
+            // Add mocks for all versions of makeRequest
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(URI.class), anyInt(), anyString()))
+                           .thenCallRealMethod();
             httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(URI.class), anyInt(), anyString(), anyBoolean()))
                            .thenCallRealMethod();
-
-            httpRequestMock.when(() -> RDAPHttpRequest.handleRequestException(any()))
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(URI.class), anyInt(), anyString(), anyBoolean(), anyBoolean()))
+                           .thenCallRealMethod();
+            httpRequestMock.when(() -> RDAPHttpRequest.handleRequestException(any(), anyBoolean()))
                            .thenCallRealMethod();
 
             HttpResponse<String> response = RDAPHttpRequest.makeRequest(testUri, timeout, "GET", true);
@@ -116,7 +139,6 @@ public class RDAPHttpRequestTest {
                 .isEqualTo(ConnectionStatus.CONNECTION_FAILED);
         }
     }
-
 
     @Test
     public void testMakeRequest_SocketTimeoutException_ReadTimeout() throws Exception {
@@ -134,9 +156,10 @@ public class RDAPHttpRequestTest {
                            .thenCallRealMethod();
             httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(URI.class), anyInt(), anyString(), anyBoolean()))
                            .thenCallRealMethod();
-            httpRequestMock.when(() -> RDAPHttpRequest.handleRequestException(any()))
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(URI.class), anyInt(), anyString(), anyBoolean(), anyBoolean()))
                            .thenCallRealMethod();
-
+            httpRequestMock.when(() -> RDAPHttpRequest.handleRequestException(any(), anyBoolean()))
+                           .thenCallRealMethod();
             HttpResponse<String> response = RDAPHttpRequest.makeRequest(testUri, timeout, "GET");
 
             assertThat(response).isInstanceOf(RDAPHttpRequest.SimpleHttpResponse.class);
@@ -162,7 +185,9 @@ public class RDAPHttpRequestTest {
                            .thenCallRealMethod();
             httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(URI.class), anyInt(), anyString(), anyBoolean()))
                            .thenCallRealMethod();
-            httpRequestMock.when(() -> RDAPHttpRequest.handleRequestException(any()))
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(URI.class), anyInt(), anyString(), anyBoolean(), anyBoolean()))
+                           .thenCallRealMethod();
+            httpRequestMock.when(() -> RDAPHttpRequest.handleRequestException(any(), anyBoolean()))
                            .thenCallRealMethod();
 
             HttpResponse<String> response = RDAPHttpRequest.makeRequest(testUri, timeout, "GET");
@@ -189,7 +214,9 @@ public class RDAPHttpRequestTest {
                            .thenCallRealMethod();
             httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(URI.class), anyInt(), anyString(), anyBoolean()))
                            .thenCallRealMethod();
-            httpRequestMock.when(() -> RDAPHttpRequest.handleRequestException(any()))
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(URI.class), anyInt(), anyString(), anyBoolean(), anyBoolean()))
+                           .thenCallRealMethod();
+            httpRequestMock.when(() -> RDAPHttpRequest.handleRequestException(any(), anyBoolean()))
                            .thenCallRealMethod();
 
             HttpResponse<String> response = RDAPHttpRequest.makeRequest(testUri, timeout, "GET");
@@ -216,7 +243,9 @@ public class RDAPHttpRequestTest {
                            .thenCallRealMethod();
             httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(URI.class), anyInt(), anyString(), anyBoolean()))
                            .thenCallRealMethod();
-            httpRequestMock.when(() -> RDAPHttpRequest.handleRequestException(any()))
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(URI.class), anyInt(), anyString(), anyBoolean(), anyBoolean()))
+                           .thenCallRealMethod();
+            httpRequestMock.when(() -> RDAPHttpRequest.handleRequestException(any(), anyBoolean()))
                            .thenCallRealMethod();
 
             HttpResponse<String> response = RDAPHttpRequest.makeRequest(testUri, timeout, "GET");
@@ -245,9 +274,10 @@ public class RDAPHttpRequestTest {
                            .thenCallRealMethod();
             httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(URI.class), anyInt(), anyString(), anyBoolean()))
                            .thenCallRealMethod();
-            httpRequestMock.when(() -> RDAPHttpRequest.handleRequestException(any()))
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(URI.class), anyInt(), anyString(), anyBoolean(), anyBoolean()))
                            .thenCallRealMethod();
-
+            httpRequestMock.when(() -> RDAPHttpRequest.handleRequestException(any(), anyBoolean()))
+                           .thenCallRealMethod();
             HttpResponse<String> response = RDAPHttpRequest.makeRequest(testUri, timeout, "GET");
 
             assertThat(response).isInstanceOf(RDAPHttpRequest.SimpleHttpResponse.class);
@@ -279,7 +309,9 @@ public class RDAPHttpRequestTest {
                            .thenCallRealMethod();
             httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(URI.class), anyInt(), anyString(), anyBoolean()))
                            .thenCallRealMethod();
-            httpRequestMock.when(() -> RDAPHttpRequest.handleRequestException(any()))
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(URI.class), anyInt(), anyString(), anyBoolean(), anyBoolean()))
+                           .thenCallRealMethod();
+            httpRequestMock.when(() -> RDAPHttpRequest.handleRequestException(any(), anyBoolean()))
                            .thenCallRealMethod();
             httpRequestMock.when(() -> RDAPHttpRequest.hasCause(any(),any()))
                            .thenCallRealMethod();
@@ -313,7 +345,9 @@ public class RDAPHttpRequestTest {
                            .thenCallRealMethod();
             httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(URI.class), anyInt(), anyString(), anyBoolean()))
                            .thenCallRealMethod();
-            httpRequestMock.when(() -> RDAPHttpRequest.handleRequestException(any()))
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(URI.class), anyInt(), anyString(), anyBoolean(), anyBoolean()))
+                           .thenCallRealMethod();
+            httpRequestMock.when(() -> RDAPHttpRequest.handleRequestException(any(), anyBoolean()))
                            .thenCallRealMethod();
             httpRequestMock.when(() -> RDAPHttpRequest.hasCause(any(), any()))
                            .thenCallRealMethod();
@@ -393,6 +427,1034 @@ public class RDAPHttpRequestTest {
             assertThat(response.statusCode()).isEqualTo(HTTP_TOO_MANY_REQUESTS);
             assertThat(((RDAPHttpRequest.SimpleHttpResponse)response).getConnectionStatusCode())
                 .isEqualTo(ConnectionStatus.TOO_MANY_REQUESTS);
+        }
+    }
+
+    @Test
+    public void testMakeRequest_NullUri() {
+        // Using TestNG's assertThrows which returns void
+        assertThrows(IllegalArgumentException.class, () ->
+            RDAPHttpRequest.makeRequest(null, timeout, GET)
+        );
+
+        // If you need to verify the message, use a try-catch approach
+        try {
+            RDAPHttpRequest.makeRequest(null, timeout, GET);
+            // Should not reach here
+            Assert.fail("Expected IllegalArgumentException was not thrown");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage()).isEqualTo("The provided URI is null.");
+        } catch (Exception e) {
+            Assert.fail("Expected IllegalArgumentException but got " + e.getClass().getName());
+        }
+    }
+
+    @Test
+    public void testMakeRequest_LocalhostResolution() throws Exception {
+        URI localhostUri = URI.create("http://localhost/path");
+
+        try (MockedStatic<DNSCacheResolver> dnsResolverMock = Mockito.mockStatic(DNSCacheResolver.class);
+            MockedStatic<RDAPHttpRequest> httpRequestMock = Mockito.mockStatic(RDAPHttpRequest.class);
+            MockedStatic<ConnectionTracker> trackerMock = Mockito.mockStatic(ConnectionTracker.class)) {
+
+            // Mock connection tracker
+            ConnectionTracker mockTracker = mock(ConnectionTracker.class);
+            when(mockTracker.startTrackingNewConnection(any(), anyString(), anyBoolean())).thenReturn("test-id");
+            trackerMock.when(ConnectionTracker::getInstance).thenReturn(mockTracker);
+
+            // Setup DNS resolution for 127.0.0.1 instead of localhost
+            InetAddress mockAddress = InetAddress.getByName(LOCAL_IPv4);
+            dnsResolverMock.when(() -> DNSCacheResolver.hasNoAddresses(LOCAL_IPv4)).thenReturn(false);
+            dnsResolverMock.when(() -> DNSCacheResolver.getFirstV4Address(LOCAL_IPv4)).thenReturn(mockAddress);
+
+            // Allow the real makeRequest to handle the localhost to 127.0.0.1 conversion
+            // but mock the rest of the execution
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(), anyInt(), anyString(), anyBoolean(), anyBoolean()))
+                           .thenCallRealMethod();
+            httpRequestMock.when(() -> RDAPHttpRequest.executeRequest(any(), any()))
+                           .thenReturn(mock(ClassicHttpResponse.class));
+
+            // Verify the call correctly resolves localhost to 127.0.0.1
+            RDAPHttpRequest.makeRequest(localhostUri, timeout, GET, true, true);
+
+            // Verify that getFirstV4Address was called with 127.0.0.1 and not localhost
+            dnsResolverMock.verify(() -> DNSCacheResolver.getFirstV4Address(eq(LOCAL_IPv4)), times(1));
+        }
+    }
+
+    @Test
+    public void testMakeRequest_NoAddressesForHost() throws Exception {
+        URI noAddressUri = URI.create("http://nonexistent.example.com/path");
+
+        try (MockedStatic<DNSCacheResolver> dnsResolverMock = Mockito.mockStatic(DNSCacheResolver.class);
+            MockedStatic<RDAPHttpRequest> httpRequestMock = Mockito.mockStatic(RDAPHttpRequest.class);
+            MockedStatic<ConnectionTracker> trackerMock = Mockito.mockStatic(ConnectionTracker.class)) {
+
+            // Mock connection tracker
+            ConnectionTracker mockTracker = mock(ConnectionTracker.class);
+            when(mockTracker.startTrackingNewConnection(any(), anyString(), anyBoolean())).thenReturn("test-id");
+            trackerMock.when(ConnectionTracker::getInstance).thenReturn(mockTracker);
+
+            // Set up DNS resolver to return no addresses for the host
+            dnsResolverMock.when(() -> DNSCacheResolver.hasNoAddresses("nonexistent.example.com")).thenReturn(true);
+
+            // Only allow real method implementation for makeRequest variants
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(), anyInt(), anyString()))
+                           .thenCallRealMethod();
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(), anyInt(), anyString(), anyBoolean()))
+                           .thenCallRealMethod();
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(), anyInt(), anyString(), anyBoolean(), anyBoolean()))
+                           .thenCallRealMethod();
+
+            // Create a mock SimpleHttpResponse with the correct status
+            RDAPHttpRequest.SimpleHttpResponse mockResponse = new RDAPHttpRequest.SimpleHttpResponse("test-id", ZERO, EMPTY_STRING, noAddressUri, new Header[0]);
+            mockResponse.setConnectionStatusCode(ConnectionStatus.UNKNOWN_HOST);
+
+            // Mock the main call to return our prepared response
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(noAddressUri, timeout, GET))
+                           .thenReturn(mockResponse);
+
+            // Execute test
+            HttpResponse<String> response = RDAPHttpRequest.makeRequest(noAddressUri, timeout, GET);
+
+            // Verify response
+            assertThat(response).isNotNull()
+                                .isInstanceOf(RDAPHttpRequest.SimpleHttpResponse.class);
+            assertThat(response.statusCode()).isEqualTo(ZERO);
+            assertThat(response.body()).isEmpty();
+            assertThat(((RDAPHttpRequest.SimpleHttpResponse)response).getConnectionStatusCode())
+                .isEqualTo(ConnectionStatus.UNKNOWN_HOST);
+
+            // Verify the correct interactions occurred
+            verify(mockTracker).startTrackingNewConnection(eq(noAddressUri), eq(GET), eq(false));
+            verify(mockTracker).completeCurrentConnection(eq(ZERO), eq(ConnectionStatus.UNKNOWN_HOST));
+        }
+    }
+
+//    @Test
+//    public void testMakeRequest_NullRemoteAddress() throws Exception {
+//        URI validUri = URI.create("http://example.com/path");
+//
+//        try (MockedStatic<DNSCacheResolver> dnsResolverMock = Mockito.mockStatic(DNSCacheResolver.class);
+//            MockedStatic<RDAPHttpRequest> httpRequestMock = Mockito.mockStatic(RDAPHttpRequest.class);
+//            MockedStatic<ConnectionTracker> trackerMock = Mockito.mockStatic(ConnectionTracker.class);
+//            MockedStatic<NetworkInfo> networkInfoMock = Mockito.mockStatic(NetworkInfo.class)) {
+//
+//            // Mock connection tracker
+//            ConnectionTracker mockTracker = mock(ConnectionTracker.class);
+//            when(mockTracker.startTrackingNewConnection(any(), anyString(), anyBoolean())).thenReturn("test-id");
+//            trackerMock.when(ConnectionTracker::getInstance).thenReturn(mockTracker);
+//
+//            // Set up DNS resolver and network info
+//            dnsResolverMock.when(() -> DNSCacheResolver.hasNoAddresses("example.com")).thenReturn(false);
+//            networkInfoMock.when(NetworkInfo::getNetworkProtocol).thenReturn(NetworkProtocol.IPv4);
+//            dnsResolverMock.when(() -> DNSCacheResolver.getFirstV4Address("example.com")).thenReturn(null);
+//
+//            // Create a mock SimpleHttpResponse with the correct status
+//            RDAPHttpRequest.SimpleHttpResponse mockResponse = new RDAPHttpRequest.SimpleHttpResponse(
+//                "test-id", ZERO, EMPTY_STRING, validUri, new Header[0]);
+//            mockResponse.setConnectionStatusCode(ConnectionStatus.UNKNOWN_HOST);
+//
+//            // Mock the makeRequest calls to return our prepared response
+//            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(validUri, timeout, GET))
+//                           .thenReturn(mockResponse);
+//            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(validUri, timeout, GET, false))
+//                           .thenReturn(mockResponse);
+//            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(validUri, timeout, GET, false, true))
+//                           .thenCallRealMethod();
+//
+//            // Execute test
+//            HttpResponse<String> response = RDAPHttpRequest.makeRequest(validUri, timeout, GET);
+//
+//            // Verify response
+//            assertThat(response).isNotNull()
+//                                .isInstanceOf(RDAPHttpRequest.SimpleHttpResponse.class);
+//            assertThat(response.statusCode()).isEqualTo(ZERO);
+//            assertThat(response.body()).isEmpty();
+//            assertThat(((RDAPHttpRequest.SimpleHttpResponse)response).getConnectionStatusCode())
+//                .isEqualTo(ConnectionStatus.UNKNOWN_HOST);
+//
+//            // Verify tracker interactions
+//            verify(mockTracker).startTrackingNewConnection(eq(validUri), eq(GET), eq(false));
+//            verify(mockTracker).completeCurrentConnection(eq(ZERO), eq(ConnectionStatus.UNKNOWN_HOST));
+//        }
+//    }
+
+
+    @Test
+    public void testMakeRequest_IPv6NetworkProtocol() throws Exception {
+        URI validUri = URI.create("http://example.com/path");
+
+        try (MockedStatic<DNSCacheResolver> dnsResolverMock = Mockito.mockStatic(DNSCacheResolver.class);
+            MockedStatic<RDAPHttpRequest> httpRequestMock = Mockito.mockStatic(RDAPHttpRequest.class);
+            MockedStatic<ConnectionTracker> trackerMock = Mockito.mockStatic(ConnectionTracker.class);
+            MockedStatic<NetworkInfo> networkInfoMock = Mockito.mockStatic(NetworkInfo.class)) {
+
+            // Mock connection tracker
+            ConnectionTracker mockTracker = mock(ConnectionTracker.class);
+            when(mockTracker.startTrackingNewConnection(any(), anyString(), anyBoolean())).thenReturn("test-id");
+            trackerMock.when(ConnectionTracker::getInstance).thenReturn(mockTracker);
+
+            // Set up for IPv6 protocol - make sure this is called before any DNS resolution
+            networkInfoMock.when(NetworkInfo::getNetworkProtocol).thenReturn(NetworkProtocol.IPv6);
+
+            // Set up DNS resolution mocks
+            dnsResolverMock.when(() -> DNSCacheResolver.hasNoAddresses("example.com")).thenReturn(false);
+            InetAddress ipv6Address = InetAddress.getByName("::1");
+            dnsResolverMock.when(() -> DNSCacheResolver.getFirstV6Address("example.com")).thenReturn(ipv6Address);
+
+            // Mock HTTP execution to return success
+            ClassicHttpResponse mockResponse = mock(ClassicHttpResponse.class);
+            when(mockResponse.getCode()).thenReturn(200);
+            when(mockResponse.getHeaders()).thenReturn(new Header[0]);
+            httpRequestMock.when(() -> RDAPHttpRequest.executeRequest(any(), any()))
+                           .thenReturn(mockResponse);
+
+            // Allow real method implementations
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(), anyInt(), anyString()))
+                           .thenCallRealMethod();
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(), anyInt(), anyString(), anyBoolean()))
+                           .thenCallRealMethod();
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(), anyInt(), anyString(), anyBoolean(), anyBoolean()))
+                           .thenCallRealMethod();
+
+            // Execute the test
+            HttpResponse<String> response = RDAPHttpRequest.makeRequest(validUri, timeout, GET);
+
+            // Verify the IPv6 resolution was called
+            dnsResolverMock.verify(() -> DNSCacheResolver.getFirstV6Address("example.com"));
+            dnsResolverMock.verify(() -> DNSCacheResolver.getFirstV4Address(anyString()), never());
+
+            // Verify response
+            assertThat(response).isInstanceOf(RDAPHttpRequest.SimpleHttpResponse.class);
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(((RDAPHttpRequest.SimpleHttpResponse)response).getConnectionStatusCode())
+                .isEqualTo(ConnectionStatus.SUCCESS);
+        }
+    }
+
+    @Test
+    public void testMakeRequest_HttpsScheme_DefaultPort() throws Exception {
+        URI httpsUri = URI.create("https://example.com/path");
+
+        try (MockedStatic<DNSCacheResolver> dnsResolverMock = Mockito.mockStatic(DNSCacheResolver.class);
+            MockedStatic<RDAPHttpRequest> httpRequestMock = Mockito.mockStatic(RDAPHttpRequest.class);
+            MockedStatic<ConnectionTracker> trackerMock = Mockito.mockStatic(ConnectionTracker.class);
+            MockedStatic<NetworkInfo> networkInfoMock = Mockito.mockStatic(NetworkInfo.class)) {
+
+            // Mock connection tracker
+            ConnectionTracker mockTracker = mock(ConnectionTracker.class);
+            when(mockTracker.startTrackingNewConnection(any(), anyString(), anyBoolean())).thenReturn("test-id");
+            trackerMock.when(ConnectionTracker::getInstance).thenReturn(mockTracker);
+
+            // Setup DNS mocks
+            dnsResolverMock.when(() -> DNSCacheResolver.hasNoAddresses("example.com")).thenReturn(false);
+            networkInfoMock.when(NetworkInfo::getNetworkProtocol).thenReturn(NetworkProtocol.IPv4);
+            InetAddress mockAddress = InetAddress.getByName("127.0.0.1");
+            dnsResolverMock.when(() -> DNSCacheResolver.getFirstV4Address("example.com")).thenReturn(mockAddress);
+
+            // Mock response
+            ClassicHttpResponse mockResponse = mock(ClassicHttpResponse.class);
+            when(mockResponse.getCode()).thenReturn(200);
+            when(mockResponse.getHeaders()).thenReturn(new Header[0]);
+
+            // Setup request capture
+            ArgumentCaptor<HttpUriRequestBase> requestCaptor = ArgumentCaptor.forClass(HttpUriRequestBase.class);
+            httpRequestMock.when(() -> RDAPHttpRequest.executeRequest(any(), any())).thenReturn(mockResponse);
+
+            // Allow real method implementations
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(), anyInt(), anyString()))
+                           .thenCallRealMethod();
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(), anyInt(), anyString(), anyBoolean()))
+                           .thenCallRealMethod();
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(), anyInt(), anyString(), anyBoolean(), anyBoolean()))
+                           .thenCallRealMethod();
+
+            // Execute test
+            HttpResponse<String> response = RDAPHttpRequest.makeRequest(httpsUri, timeout, GET);
+
+            // Verify the captured request after the method execution
+            httpRequestMock.verify(() -> RDAPHttpRequest.executeRequest(any(), requestCaptor.capture()));
+            HttpUriRequestBase capturedRequest = requestCaptor.getValue();
+
+            // Verify port is 443
+            assertThat(capturedRequest.getUri().getPort()).isEqualTo(443);
+
+            // Verify response
+            assertThat(response).isInstanceOf(RDAPHttpRequest.SimpleHttpResponse.class);
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(((RDAPHttpRequest.SimpleHttpResponse)response).getConnectionStatusCode())
+                .isEqualTo(ConnectionStatus.SUCCESS);
+        }
+    }
+
+
+    @Test
+    public void testMakeRequest_HttpScheme_DefaultPort() throws Exception {
+        // Test with HTTP URI that doesn't specify a port
+        URI httpUri = URI.create("http://example.com/path");
+
+        try (MockedStatic<DNSCacheResolver> dnsResolverMock = Mockito.mockStatic(DNSCacheResolver.class);
+            MockedStatic<RDAPHttpRequest> httpRequestMock = Mockito.mockStatic(RDAPHttpRequest.class);
+            MockedStatic<ConnectionTracker> trackerMock = Mockito.mockStatic(ConnectionTracker.class);
+            MockedStatic<NetworkInfo> networkInfoMock = Mockito.mockStatic(NetworkInfo.class)) {
+
+            // Mock connection tracker
+            ConnectionTracker mockTracker = mock(ConnectionTracker.class);
+            when(mockTracker.startTrackingNewConnection(any(), anyString(), anyBoolean())).thenReturn("test-id");
+            trackerMock.when(ConnectionTracker::getInstance).thenReturn(mockTracker);
+
+            // Setup DNS mocks
+            dnsResolverMock.when(() -> DNSCacheResolver.hasNoAddresses("example.com")).thenReturn(false);
+            networkInfoMock.when(NetworkInfo::getNetworkProtocol).thenReturn(NetworkProtocol.IPv4);
+            InetAddress mockAddress = InetAddress.getByName("127.0.0.1");
+            dnsResolverMock.when(() -> DNSCacheResolver.getFirstV4Address("example.com")).thenReturn(mockAddress);
+
+            // Mock response
+            ClassicHttpResponse mockResponse = mock(ClassicHttpResponse.class);
+            when(mockResponse.getCode()).thenReturn(200);
+            when(mockResponse.getHeaders()).thenReturn(new Header[0]);
+
+            // Setup request capture
+            ArgumentCaptor<HttpUriRequestBase> requestCaptor = ArgumentCaptor.forClass(HttpUriRequestBase.class);
+            httpRequestMock.when(() -> RDAPHttpRequest.executeRequest(any(), requestCaptor.capture())).thenReturn(mockResponse);
+
+            // Allow real method implementations
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(), anyInt(), anyString()))
+                           .thenCallRealMethod();
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(), anyInt(), anyString(), anyBoolean()))
+                           .thenCallRealMethod();
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(), anyInt(), anyString(), anyBoolean(), anyBoolean()))
+                           .thenCallRealMethod();
+
+            // Execute test
+            HttpResponse<String> response = RDAPHttpRequest.makeRequest(httpUri, timeout, GET);
+
+            // Get the captured request and verify its properties
+            HttpUriRequestBase capturedRequest = requestCaptor.getValue();
+
+            // Verify port is 80
+            assertThat(capturedRequest.getUri().getPort()).isEqualTo(80);
+
+            // Verify response
+            assertThat(response).isInstanceOf(RDAPHttpRequest.SimpleHttpResponse.class);
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(((RDAPHttpRequest.SimpleHttpResponse)response).getConnectionStatusCode())
+                .isEqualTo(ConnectionStatus.SUCCESS);
+        }
+    }
+
+    @Test
+    public void testMakeRequest_CustomPort() throws Exception {
+        // Test with URI that specifies a custom port
+        URI customPortUri = URI.create("http://example.com:8080/path");
+
+        try (MockedStatic<DNSCacheResolver> dnsResolverMock = Mockito.mockStatic(DNSCacheResolver.class);
+            MockedStatic<RDAPHttpRequest> httpRequestMock = Mockito.mockStatic(RDAPHttpRequest.class);
+            MockedStatic<ConnectionTracker> trackerMock = Mockito.mockStatic(ConnectionTracker.class);
+            MockedStatic<NetworkInfo> networkInfoMock = Mockito.mockStatic(NetworkInfo.class)) {
+
+            // Mock connection tracker
+            ConnectionTracker mockTracker = mock(ConnectionTracker.class);
+            when(mockTracker.startTrackingNewConnection(any(), anyString(), anyBoolean())).thenReturn("test-id");
+            trackerMock.when(ConnectionTracker::getInstance).thenReturn(mockTracker);
+
+            // Setup DNS mocks
+            dnsResolverMock.when(() -> DNSCacheResolver.hasNoAddresses("example.com")).thenReturn(false);
+            networkInfoMock.when(NetworkInfo::getNetworkProtocol).thenReturn(NetworkProtocol.IPv4);
+            InetAddress mockAddress = InetAddress.getByName("127.0.0.1");
+            dnsResolverMock.when(() -> DNSCacheResolver.getFirstV4Address("example.com")).thenReturn(mockAddress);
+
+            // Mock response
+            ClassicHttpResponse mockResponse = mock(ClassicHttpResponse.class);
+            when(mockResponse.getCode()).thenReturn(200);
+            when(mockResponse.getHeaders()).thenReturn(new Header[0]);
+
+            // Setup request capture
+            ArgumentCaptor<HttpUriRequestBase> requestCaptor = ArgumentCaptor.forClass(HttpUriRequestBase.class);
+            httpRequestMock.when(() -> RDAPHttpRequest.executeRequest(any(), requestCaptor.capture()))
+                           .thenReturn(mockResponse);
+
+            // Allow real method implementations
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(), anyInt(), anyString()))
+                           .thenCallRealMethod();
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(), anyInt(), anyString(), anyBoolean()))
+                           .thenCallRealMethod();
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(), anyInt(), anyString(), anyBoolean(), anyBoolean()))
+                           .thenCallRealMethod();
+
+            // Execute test
+            HttpResponse<String> response = RDAPHttpRequest.makeRequest(customPortUri, timeout, GET);
+
+            // Get the captured request and verify its properties
+            HttpUriRequestBase capturedRequest = requestCaptor.getValue();
+
+            // Verify port is 8080
+            assertThat(capturedRequest.getUri().getPort()).isEqualTo(8080);
+
+            // Verify response
+            assertThat(response).isInstanceOf(RDAPHttpRequest.SimpleHttpResponse.class);
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(((RDAPHttpRequest.SimpleHttpResponse)response).getConnectionStatusCode())
+                .isEqualTo(ConnectionStatus.SUCCESS);
+        }
+    }
+
+    @Test
+    public void testHandleRequestException_UnknownHostExceptionFull() throws Exception {
+        try (MockedStatic<DNSCacheResolver> dnsResolverMock = mockStatic(DNSCacheResolver.class);
+            MockedStatic<RDAPHttpRequest> httpRequestMock = mockStatic(RDAPHttpRequest.class);
+            MockedStatic<CommonUtils> commonUtilsMock = mockStatic(CommonUtils.class)) {
+
+            // Setup DNS mocks
+            dnsResolverMock.when(() -> DNSCacheResolver.hasNoAddresses(anyString())).thenReturn(false);
+            InetAddress mockAddress = InetAddress.getByName("127.0.0.1");
+            dnsResolverMock.when(() -> DNSCacheResolver.getFirstV4Address(anyString())).thenReturn(mockAddress);
+
+            // Create the exception
+            UnknownHostException ex = new UnknownHostException("Unknown host");
+
+            // Setup the execution chain
+            httpRequestMock.when(() -> RDAPHttpRequest.executeRequest(any(), any()))
+                           .thenThrow(ex);
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(URI.class), anyInt(), anyString()))
+                           .thenCallRealMethod();
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(URI.class), anyInt(), anyString(), anyBoolean()))
+                           .thenCallRealMethod();
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(URI.class), anyInt(), anyString(), anyBoolean(), anyBoolean()))
+                           .thenCallRealMethod();
+            httpRequestMock.when(() -> RDAPHttpRequest.handleRequestException(any(), anyBoolean()))
+                           .thenCallRealMethod();
+            httpRequestMock.when(() -> RDAPHttpRequest.hasCause(any(), any()))
+                           .thenCallRealMethod();
+
+            // Execute the test
+            HttpResponse<String> response = RDAPHttpRequest.makeRequest(testUri, timeout, GET);
+
+            // Verify results
+            assertThat(response).isInstanceOf(RDAPHttpRequest.SimpleHttpResponse.class);
+            assertThat(((RDAPHttpRequest.SimpleHttpResponse)response).getConnectionStatusCode())
+                .isEqualTo(ConnectionStatus.UNKNOWN_HOST);
+        }
+    }
+
+    @Test
+    public void testHandleRequestException_ConnectExceptionFull() throws Exception {
+        try (MockedStatic<DNSCacheResolver> dnsResolverMock = mockStatic(DNSCacheResolver.class);
+            MockedStatic<RDAPHttpRequest> httpRequestMock = mockStatic(RDAPHttpRequest.class);
+            MockedStatic<CommonUtils> commonUtilsMock = mockStatic(CommonUtils.class)) {
+
+            // Setup DNS mocks
+            dnsResolverMock.when(() -> DNSCacheResolver.hasNoAddresses(anyString())).thenReturn(false);
+            InetAddress mockAddress = InetAddress.getByName("127.0.0.1");
+            dnsResolverMock.when(() -> DNSCacheResolver.getFirstV4Address(anyString())).thenReturn(mockAddress);
+
+            // Create the exception
+            ConnectException ex = new ConnectException("Connection refused");
+
+            // Setup the execution chain
+            httpRequestMock.when(() -> RDAPHttpRequest.executeRequest(any(), any()))
+                           .thenThrow(ex);
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(URI.class), anyInt(), anyString()))
+                           .thenCallRealMethod();
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(URI.class), anyInt(), anyString(), anyBoolean()))
+                           .thenCallRealMethod();
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(URI.class), anyInt(), anyString(), anyBoolean(), anyBoolean()))
+                           .thenCallRealMethod();
+            httpRequestMock.when(() -> RDAPHttpRequest.handleRequestException(any(), anyBoolean()))
+                           .thenCallRealMethod();
+            httpRequestMock.when(() -> RDAPHttpRequest.hasCause(any(), any()))
+                           .thenCallRealMethod();
+
+            // Execute the test
+            HttpResponse<String> response = RDAPHttpRequest.makeRequest(testUri, timeout, GET);
+
+            // Verify results
+            assertThat(response).isInstanceOf(RDAPHttpRequest.SimpleHttpResponse.class);
+            assertThat(((RDAPHttpRequest.SimpleHttpResponse)response).getConnectionStatusCode())
+                .isEqualTo(ConnectionStatus.CONNECTION_FAILED);
+
+            // Verify error was added
+            commonUtilsMock.verify(() ->
+                CommonUtils.addErrorToResultsFile(eq(ZERO), eq(-13007), eq("no response available"),
+                    eq("Failed to connect to server.")), times(1));
+        }
+    }
+
+
+    @Test
+    public void testHandleRequestException_SocketTimeoutReadTimeoutFull() throws Exception {
+        try (MockedStatic<DNSCacheResolver> dnsResolverMock = mockStatic(DNSCacheResolver.class);
+            MockedStatic<RDAPHttpRequest> httpRequestMock = mockStatic(RDAPHttpRequest.class);
+            MockedStatic<CommonUtils> commonUtilsMock = mockStatic(CommonUtils.class)) {
+
+            // Setup DNS mocks
+            dnsResolverMock.when(() -> DNSCacheResolver.hasNoAddresses(anyString())).thenReturn(false);
+            InetAddress mockAddress = InetAddress.getByName("127.0.0.1");
+            dnsResolverMock.when(() -> DNSCacheResolver.getFirstV4Address(anyString())).thenReturn(mockAddress);
+
+            // Create the exception
+            SocketTimeoutException ex = new SocketTimeoutException("Read timed out");
+
+            // Setup the execution chain
+            httpRequestMock.when(() -> RDAPHttpRequest.executeRequest(any(), any()))
+                           .thenThrow(ex);
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(URI.class), anyInt(), anyString()))
+                           .thenCallRealMethod();
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(URI.class), anyInt(), anyString(), anyBoolean()))
+                           .thenCallRealMethod();
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(URI.class), anyInt(), anyString(), anyBoolean(), anyBoolean()))
+                           .thenCallRealMethod();
+            httpRequestMock.when(() -> RDAPHttpRequest.handleRequestException(any(), anyBoolean()))
+                           .thenCallRealMethod();
+            httpRequestMock.when(() -> RDAPHttpRequest.hasCause(any(), any()))
+                           .thenCallRealMethod();
+
+            // Execute the test
+            HttpResponse<String> response = RDAPHttpRequest.makeRequest(testUri, timeout, GET);
+
+            // Verify results
+            assertThat(response).isInstanceOf(RDAPHttpRequest.SimpleHttpResponse.class);
+            assertThat(((RDAPHttpRequest.SimpleHttpResponse)response).getConnectionStatusCode())
+                .isEqualTo(ConnectionStatus.NETWORK_RECEIVE_FAIL);
+
+            // Verify error was added
+            commonUtilsMock.verify(() ->
+                CommonUtils.addErrorToResultsFile(eq(ZERO), eq(-13017), eq("no response available"),
+                    eq("Network receive fail")), times(1));
+        }
+    }
+
+    @Test
+    public void testHandleRequestException_SocketTimeoutConnectTimeoutFull() throws Exception {
+        try (MockedStatic<DNSCacheResolver> dnsResolverMock = mockStatic(DNSCacheResolver.class);
+            MockedStatic<RDAPHttpRequest> httpRequestMock = mockStatic(RDAPHttpRequest.class);
+            MockedStatic<CommonUtils> commonUtilsMock = mockStatic(CommonUtils.class)) {
+
+            // Setup DNS mocks
+            dnsResolverMock.when(() -> DNSCacheResolver.hasNoAddresses(anyString())).thenReturn(false);
+            InetAddress mockAddress = InetAddress.getByName("127.0.0.1");
+            dnsResolverMock.when(() -> DNSCacheResolver.getFirstV4Address(anyString())).thenReturn(mockAddress);
+
+            // Create the exception
+            SocketTimeoutException ex = new SocketTimeoutException("Connect timed out");
+
+            // Setup the execution chain
+            httpRequestMock.when(() -> RDAPHttpRequest.executeRequest(any(), any()))
+                           .thenThrow(ex);
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(URI.class), anyInt(), anyString()))
+                           .thenCallRealMethod();
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(URI.class), anyInt(), anyString(), anyBoolean()))
+                           .thenCallRealMethod();
+            httpRequestMock.when(() -> RDAPHttpRequest.makeRequest(any(URI.class), anyInt(), anyString(), anyBoolean(), anyBoolean()))
+                           .thenCallRealMethod();
+            httpRequestMock.when(() -> RDAPHttpRequest.handleRequestException(any(), anyBoolean()))
+                           .thenCallRealMethod();
+            httpRequestMock.when(() -> RDAPHttpRequest.hasCause(any(), any()))
+                           .thenCallRealMethod();
+
+            // Execute the test
+            HttpResponse<String> response = RDAPHttpRequest.makeRequest(testUri, timeout, GET);
+
+            // Verify results
+            assertThat(response).isInstanceOf(RDAPHttpRequest.SimpleHttpResponse.class);
+            assertThat(((RDAPHttpRequest.SimpleHttpResponse)response).getConnectionStatusCode())
+                .isEqualTo(ConnectionStatus.NETWORK_SEND_FAIL);
+
+            // Verify error was added
+            commonUtilsMock.verify(() ->
+                CommonUtils.addErrorToResultsFile(eq(ZERO), eq(-13016), eq("no response available"),
+                    eq("Network send fail")), times(1));
+        }
+    }
+
+
+
+    // XXX --> <--- XXX
+    @Test
+    public void testHandleRequestException_UnknownHostException() {
+        try (MockedStatic<CommonUtils> commonUtilsMock = mockStatic(CommonUtils.class)) {
+            // Get and clear the real results instance
+            RDAPValidatorResultsImpl results = RDAPValidatorResultsImpl.getInstance();
+            results.clear();
+
+            // Test with recordError = true
+            UnknownHostException ex = new UnknownHostException("Unknown host");
+            ConnectionStatus status = RDAPHttpRequest.handleRequestException(ex, true);
+
+            // Verify correct status is returned
+            assertThat(status).isEqualTo(ConnectionStatus.UNKNOWN_HOST);
+
+            // Test with recordError = false
+            ex = new UnknownHostException("Unknown host");
+            status = RDAPHttpRequest.handleRequestException(ex, false);
+
+            // Verify correct status is returned but no error recorded
+            assertThat(status).isEqualTo(ConnectionStatus.UNKNOWN_HOST);
+
+            // Verify error recording methods were called correctly
+            commonUtilsMock.verify(() ->
+                    CommonUtils.addErrorToResultsFile(anyInt(), anyInt(), anyString(), anyString()),
+                never());
+        }
+    }
+
+    @Test
+    public void testHandleRequestException_ConnectException() {
+        try (MockedStatic<CommonUtils> commonUtilsMock = mockStatic(CommonUtils.class)) {
+            // Get and clear the real results instance
+            RDAPValidatorResultsImpl results = RDAPValidatorResultsImpl.getInstance();
+            results.clear();
+
+            // Test with recordError = true
+            ConnectException ex = new ConnectException("Connection refused");
+            ConnectionStatus status = RDAPHttpRequest.handleRequestException(ex, true);
+
+            // Verify correct status is returned
+            assertThat(status).isEqualTo(ConnectionStatus.CONNECTION_FAILED);
+
+            // Verify error is added with correct code
+            commonUtilsMock.verify(() ->
+                    CommonUtils.addErrorToResultsFile(eq(0), eq(-13007), eq("no response available"),
+                        eq("Failed to connect to server.")),
+                times(1));
+
+            // Test with recordError = false
+            status = RDAPHttpRequest.handleRequestException(ex, false);
+
+            // Verify correct status is returned but no additional error recorded
+            assertThat(status).isEqualTo(ConnectionStatus.CONNECTION_FAILED);
+            commonUtilsMock.verify(() ->
+                    CommonUtils.addErrorToResultsFile(anyInt(), anyInt(), anyString(), anyString()),
+                times(1)); // Still just 1 call from before
+        }
+    }
+
+    @Test
+    public void testHandleRequestException_HttpTimeoutException() {
+        try (MockedStatic<CommonUtils> commonUtilsMock = mockStatic(CommonUtils.class)) {
+            // Get and clear the real results instance
+            RDAPValidatorResultsImpl results = RDAPValidatorResultsImpl.getInstance();
+            results.clear();
+
+            // Test with recordError = true
+            java.net.http.HttpTimeoutException ex = new java.net.http.HttpTimeoutException("Request timed out");
+            ConnectionStatus status = RDAPHttpRequest.handleRequestException(ex, true);
+
+            // Verify correct status is returned
+            assertThat(status).isEqualTo(ConnectionStatus.CONNECTION_FAILED);
+
+            // Verify error is added with correct code
+            commonUtilsMock.verify(() ->
+                    CommonUtils.addErrorToResultsFile(eq(0), eq(-13007), eq("no response available"),
+                        eq("Failed to connect to server.")),
+                times(1));
+        }
+    }
+
+    @Test
+    public void testHandleRequestException_UnresolvedAddressException() {
+        try (MockedStatic<CommonUtils> commonUtilsMock = mockStatic(CommonUtils.class);
+            MockedStatic<RDAPHttpRequest> httpRequestMock = mockStatic(RDAPHttpRequest.class,
+                invocation -> {
+                    if (!invocation.getMethod().getName().equals("hasCause")) {
+                        return invocation.callRealMethod();
+                    }
+                    return null;
+                })) {
+
+            // Get and clear the real results instance
+            RDAPValidatorResultsImpl results = RDAPValidatorResultsImpl.getInstance();
+            results.clear();
+
+            // Create a custom exception with the right cause for UnresolvedAddressException
+            IOException ioEx = new ConnectException("Connection failed");
+            Exception unresolvedEx = new Exception("java.nio.channels.UnresolvedAddressException");
+            ioEx.initCause(unresolvedEx);
+
+            // Mock hasCause to return true for this specific cause
+            httpRequestMock.when(() -> RDAPHttpRequest.hasCause(eq(ioEx), eq("java.nio.channels.UnresolvedAddressException")))
+                           .thenReturn(true);
+
+            // Test with recordError = true
+            ConnectionStatus status = RDAPHttpRequest.handleRequestException(ioEx, true);
+
+            // Verify correct status is returned
+            assertThat(status).isEqualTo(ConnectionStatus.NETWORK_SEND_FAIL);
+
+            // Verify correct error is added
+            commonUtilsMock.verify(() ->
+                    CommonUtils.addErrorToResultsFile(eq(0), eq(-13016), eq("no response available"),
+                        eq("Network send fail")),
+                times(1));
+        }
+    }
+
+    @Test
+    public void testHandleRequestException_CertificateExpiredException() {
+        try (MockedStatic<CommonUtils> commonUtilsMock = mockStatic(CommonUtils.class);
+            MockedStatic<RDAPHttpRequest> httpRequestMock = mockStatic(RDAPHttpRequest.class,
+                invocation -> {
+                    if (!invocation.getMethod().getName().equals("hasCause")) {
+                        return invocation.callRealMethod();
+                    }
+                    return null;
+                })) {
+
+            // Get and clear the real results instance
+            RDAPValidatorResultsImpl results = RDAPValidatorResultsImpl.getInstance();
+            results.clear();
+
+            // Create a chain of exceptions for expired certificate
+            CertificateExpiredException certEx = new CertificateExpiredException("Certificate expired");
+            SSLHandshakeException sslEx = new SSLHandshakeException("Certificate validation failed");
+            sslEx.initCause(certEx);
+            IOException ioEx = new IOException("SSL handshake failed");
+            ioEx.initCause(sslEx);
+
+            // Mock hasCause method
+            httpRequestMock.when(() ->
+                               RDAPHttpRequest.hasCause(eq(ioEx), eq("java.security.cert.CertificateExpiredException")))
+                           .thenReturn(true);
+
+            // Test with recordError = true
+            ConnectionStatus status = RDAPHttpRequest.handleRequestException(ioEx, true);
+
+            // Verify correct status is returned
+            assertThat(status).isEqualTo(ConnectionStatus.EXPIRED_CERTIFICATE);
+
+            // Verify correct error is added
+            commonUtilsMock.verify(() ->
+                    CommonUtils.addErrorToResultsFile(eq(0), eq(-13011), eq("no response available"),
+                        eq("Expired certificate.")),
+                times(1));
+
+            // Test with recordError = false
+            status = RDAPHttpRequest.handleRequestException(ioEx, false);
+
+            // Verify correct status is returned but no additional error
+            assertThat(status).isEqualTo(ConnectionStatus.EXPIRED_CERTIFICATE);
+            commonUtilsMock.verify(() ->
+                    CommonUtils.addErrorToResultsFile(anyInt(), anyInt(), anyString(), anyString()),
+                times(1)); // Should still be 1 from before
+        }
+    }
+
+    @Test
+    public void testHandleRequestException_CertificateRevokedException() {
+        try (MockedStatic<CommonUtils> commonUtilsMock = mockStatic(CommonUtils.class);
+            MockedStatic<RDAPHttpRequest> httpRequestMock = mockStatic(RDAPHttpRequest.class,
+                invocation -> {
+                    if (!invocation.getMethod().getName().equals("hasCause")) {
+                        return invocation.callRealMethod();
+                    }
+                    return null;
+                })) {
+
+            // Get and clear the real results instance
+            RDAPValidatorResultsImpl results = RDAPValidatorResultsImpl.getInstance();
+            results.clear();
+
+            // Create an IOException with the right cause chain
+            IOException ioEx = new IOException("SSL handshake failed");
+
+            // Mock hasCause to return true for this specific cause
+            httpRequestMock.when(() ->
+                               RDAPHttpRequest.hasCause(eq(ioEx), eq("java.security.cert.CertificateRevokedException")))
+                           .thenReturn(true);
+
+            // Test with recordError = true
+            ConnectionStatus status = RDAPHttpRequest.handleRequestException(ioEx, true);
+
+            // Verify correct status is returned
+            assertThat(status).isEqualTo(ConnectionStatus.REVOKED_CERTIFICATE);
+
+            // Verify correct error is added
+            commonUtilsMock.verify(() ->
+                    CommonUtils.addErrorToResultsFile(eq(0), eq(-13010), eq("no response available"),
+                        eq("Revoked TLS certificate.")),
+                times(1));
+        }
+    }
+
+    @Test
+    public void testHandleRequestException_InvalidCertificate() {
+        try (MockedStatic<CommonUtils> commonUtilsMock = mockStatic(CommonUtils.class);
+            MockedStatic<RDAPHttpRequest> httpRequestMock = mockStatic(RDAPHttpRequest.class,
+                invocation -> {
+                    if (!invocation.getMethod().getName().equals("hasCause")) {
+                        return invocation.callRealMethod();
+                    }
+                    return null;
+                })) {
+
+            // Get and clear the real results instance
+            RDAPValidatorResultsImpl results = RDAPValidatorResultsImpl.getInstance();
+            results.clear();
+
+            // Create an exception with proper message
+            IOException ioEx = new IOException("No name matching example.com found");
+            ioEx.initCause(new java.security.cert.CertificateException(
+                "No subject alternative DNS name matching example.com found"));
+
+            // Mock hasCause to return true for CertificateException
+            httpRequestMock.when(() ->
+                               RDAPHttpRequest.hasCause(eq(ioEx), eq("java.security.cert.CertificateException")))
+                           .thenReturn(true);
+
+            // Test with recordError = true
+            ConnectionStatus status = RDAPHttpRequest.handleRequestException(ioEx, true);
+
+            // Verify correct status is returned
+            assertThat(status).isEqualTo(ConnectionStatus.INVALID_CERTIFICATE);
+
+            // Verify correct error is added
+            commonUtilsMock.verify(() ->
+                    CommonUtils.addErrorToResultsFile(eq(0), eq(-13009), eq("no response available"),
+                        eq("Invalid TLS certificate.")),
+                times(1));
+        }
+    }
+
+    @Test
+    public void testHandleRequestException_OtherCertificateError() {
+        try (MockedStatic<CommonUtils> commonUtilsMock = mockStatic(CommonUtils.class);
+            MockedStatic<RDAPHttpRequest> httpRequestMock = mockStatic(RDAPHttpRequest.class,
+                invocation -> {
+                    if (!invocation.getMethod().getName().equals("hasCause")) {
+                        return invocation.callRealMethod();
+                    }
+                    return null;
+                })) {
+
+            // Get and clear the real results instance
+            RDAPValidatorResultsImpl results = RDAPValidatorResultsImpl.getInstance();
+            results.clear();
+
+            // Create an exception for a general certificate error
+            IOException ioEx = new IOException("Certificate error");
+            ioEx.initCause(new java.security.cert.CertificateException("General certificate error"));
+
+            // Mock hasCause to return true for CertificateException
+            httpRequestMock.when(() ->
+                               RDAPHttpRequest.hasCause(eq(ioEx), eq("java.security.cert.CertificateException")))
+                           .thenReturn(true);
+
+            // Test with recordError = true
+            ConnectionStatus status = RDAPHttpRequest.handleRequestException(ioEx, true);
+
+            // Verify correct status is returned
+            assertThat(status).isEqualTo(ConnectionStatus.CERTIFICATE_ERROR);
+
+            // Verify correct error is added
+            commonUtilsMock.verify(() ->
+                    CommonUtils.addErrorToResultsFile(eq(0), eq(-13012), eq("no response available"),
+                        eq("TLS certificate error.")),
+                times(1));
+        }
+    }
+
+    @Test
+    public void testHandleRequestException_SSLHandshakeException() {
+        try (MockedStatic<CommonUtils> commonUtilsMock = mockStatic(CommonUtils.class);
+            MockedStatic<RDAPHttpRequest> httpRequestMock = mockStatic(RDAPHttpRequest.class,
+                invocation -> {
+                    if (!invocation.getMethod().getName().equals("hasCause")) {
+                        return invocation.callRealMethod();
+                    }
+                    return null;
+                })) {
+
+            // Get and clear the real results instance
+            RDAPValidatorResultsImpl results = RDAPValidatorResultsImpl.getInstance();
+            results.clear();
+
+            // Create an exception for SSL handshake failure
+            SSLHandshakeException sslEx = new SSLHandshakeException("PKIX path building failed");
+            IOException ioEx = new IOException("SSL handshake failed");
+            ioEx.initCause(sslEx);
+
+            // Mock hasCause to return true for SSLHandshakeException
+            httpRequestMock.when(() ->
+                               RDAPHttpRequest.hasCause(eq(ioEx), eq("javax.net.ssl.SSLHandshakeException")))
+                           .thenReturn(true);
+
+            // Test with recordError = true
+            ConnectionStatus status = RDAPHttpRequest.handleRequestException(ioEx, true);
+
+            // Verify correct status is returned
+            assertThat(status).isEqualTo(ConnectionStatus.HANDSHAKE_FAILED);
+
+            // Verify correct error is added
+            commonUtilsMock.verify(() ->
+                    CommonUtils.addErrorToResultsFile(eq(0), eq(-13008), eq("no response available"),
+                        eq("TLS handshake failed.")),
+                times(1));
+        }
+    }
+
+    @Test
+    public void testHandleRequestException_ValidatorException() {
+        try (MockedStatic<CommonUtils> commonUtilsMock = mockStatic(CommonUtils.class);
+            MockedStatic<RDAPHttpRequest> httpRequestMock = mockStatic(RDAPHttpRequest.class,
+                invocation -> {
+                    if (!invocation.getMethod().getName().equals("hasCause")) {
+                        return invocation.callRealMethod();
+                    }
+                    return null;
+                })) {
+
+            // Get and clear the real results instance
+            RDAPValidatorResultsImpl results = RDAPValidatorResultsImpl.getInstance();
+            results.clear();
+
+            // Create an exception with ValidatorException in the chain
+            IOException ioEx = new IOException("Certificate validation failed");
+
+            // Mock hasCause to return true for ValidatorException
+            httpRequestMock.when(() ->
+                               RDAPHttpRequest.hasCause(eq(ioEx), eq("sun.security.validator.ValidatorException")))
+                           .thenReturn(true);
+
+            // Test with recordError = true
+            ConnectionStatus status = RDAPHttpRequest.handleRequestException(ioEx, true);
+
+            // Verify correct status is returned
+            assertThat(status).isEqualTo(ConnectionStatus.CERTIFICATE_ERROR);
+
+            // Verify correct error is added
+            commonUtilsMock.verify(() ->
+                    CommonUtils.addErrorToResultsFile(eq(0), eq(-13012), eq("no response available"),
+                        eq("TLS certificate error.")),
+                times(1));
+        }
+    }
+
+    @Test
+    public void testHandleRequestException_SocketTimeoutReadTimeout() {
+        try (MockedStatic<CommonUtils> commonUtilsMock = mockStatic(CommonUtils.class)) {
+            // Get and clear the real results instance
+            RDAPValidatorResultsImpl results = RDAPValidatorResultsImpl.getInstance();
+            results.clear();
+
+            // Test with recordError = true
+            SocketTimeoutException ex = new SocketTimeoutException("Read timed out");
+            ConnectionStatus status = RDAPHttpRequest.handleRequestException(ex, true);
+
+            // Verify correct status is returned
+            assertThat(status).isEqualTo(ConnectionStatus.NETWORK_RECEIVE_FAIL);
+
+            // Verify correct error is added
+            commonUtilsMock.verify(() ->
+                    CommonUtils.addErrorToResultsFile(eq(0), eq(-13017), eq("no response available"),
+                        eq("Network receive fail")),
+                times(1));
+        }
+    }
+
+    @Test
+    public void testHandleRequestException_SocketTimeoutConnectTimeout() {
+        try (MockedStatic<CommonUtils> commonUtilsMock = mockStatic(CommonUtils.class)) {
+            // Get and clear the real results instance
+            RDAPValidatorResultsImpl results = RDAPValidatorResultsImpl.getInstance();
+            results.clear();
+
+            // Test with recordError = true
+            SocketTimeoutException ex = new SocketTimeoutException("Connect timed out");
+            ConnectionStatus status = RDAPHttpRequest.handleRequestException(ex, true);
+
+            // Verify correct status is returned
+            assertThat(status).isEqualTo(ConnectionStatus.NETWORK_SEND_FAIL);
+
+            // Verify correct error is added
+            commonUtilsMock.verify(() ->
+                    CommonUtils.addErrorToResultsFile(eq(0), eq(-13016), eq("no response available"),
+                        eq("Network send fail")),
+                times(1));
+        }
+    }
+
+    @Test
+    public void testHandleRequestException_EOFException() {
+        try (MockedStatic<CommonUtils> commonUtilsMock = mockStatic(CommonUtils.class)) {
+            // Get and clear the real results instance
+            RDAPValidatorResultsImpl results = RDAPValidatorResultsImpl.getInstance();
+            results.clear();
+
+            // Test with recordError = true
+            EOFException ex = new EOFException("Unexpected end of file");
+            ConnectionStatus status = RDAPHttpRequest.handleRequestException(ex, true);
+
+            // Verify correct status is returned
+            assertThat(status).isEqualTo(ConnectionStatus.NETWORK_RECEIVE_FAIL);
+
+            // Verify correct error is added
+            commonUtilsMock.verify(() ->
+                    CommonUtils.addErrorToResultsFile(eq(0), eq(-13017), eq("no response available"),
+                        eq("Network receive fail")),
+                times(1));
+        }
+    }
+
+    @Test
+    public void testHandleRequestException_ConnectionReset() {
+        try (MockedStatic<CommonUtils> commonUtilsMock = mockStatic(CommonUtils.class)) {
+            // Get and clear the real results instance
+            RDAPValidatorResultsImpl results = RDAPValidatorResultsImpl.getInstance();
+            results.clear();
+
+            // Test with recordError = true
+            IOException ex = new IOException("Connection reset");
+            ConnectionStatus status = RDAPHttpRequest.handleRequestException(ex, true);
+
+            // Verify correct status is returned
+            assertThat(status).isEqualTo(ConnectionStatus.NETWORK_RECEIVE_FAIL);
+
+            // Verify correct error is added
+            commonUtilsMock.verify(() ->
+                    CommonUtils.addErrorToResultsFile(eq(0), eq(-13017), eq("no response available"),
+                        eq("Network receive fail")),
+                times(1));
+        }
+    }
+
+    @Test
+    public void testHandleRequestException_ConnectionClosedByPeer() {
+        try (MockedStatic<CommonUtils> commonUtilsMock = mockStatic(CommonUtils.class)) {
+            // Get and clear the real results instance
+            RDAPValidatorResultsImpl results = RDAPValidatorResultsImpl.getInstance();
+            results.clear();
+
+            // Test with recordError = true
+            IOException ex = new IOException("Connection closed by peer");
+            ConnectionStatus status = RDAPHttpRequest.handleRequestException(ex, true);
+
+            // Verify correct status is returned
+            assertThat(status).isEqualTo(ConnectionStatus.NETWORK_RECEIVE_FAIL);
+
+            // Verify correct error is added
+            commonUtilsMock.verify(() ->
+                    CommonUtils.addErrorToResultsFile(eq(0), eq(-13017), eq("no response available"),
+                        eq("Network receive fail")),
+                times(1));
+        }
+    }
+
+    @Test
+    public void testHandleRequestException_GenericIOException() {
+        try (MockedStatic<CommonUtils> commonUtilsMock = mockStatic(CommonUtils.class)) {
+
+            RDAPValidatorResultsImpl results = RDAPValidatorResultsImpl.getInstance();
+            results.clear();
+
+            IOException ex = new IOException("Some other IO error");
+            ConnectionStatus status = RDAPHttpRequest.handleRequestException(ex, true);
+
+            assertThat(status).isEqualTo(ConnectionStatus.CONNECTION_FAILED);
+            commonUtilsMock.verify(() ->
+                    CommonUtils.addErrorToResultsFile(eq(ZERO), eq(-13007), eq("no response available"),
+                        eq("Failed to connect to server.")),
+                times(ONE));
         }
     }
 

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpRequestTest.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpRequestTest.java
@@ -49,7 +49,7 @@ public class RDAPHttpRequestTest {
     public static final int HTTP_HIGH_PORT = 8080;
     private final URI testUri = URI.create("http://example.com/path");
     private final int timeout = 10;
-    
+
     @Test
     public void testMakeRequest_UnknownHost() throws Exception {
         try (MockedStatic<DNSCacheResolver> dnsResolverMock = Mockito.mockStatic(DNSCacheResolver.class);


### PR DESCRIPTION
CHANGE:
refactored how makeRequest is called so that in TigValidation1Dot2 we don't record the connection fail as an error - which we do not want to do, in this case.
Also, refactored and added tests for the exception, especially pertaining to the new recordError boolean flag