### PR TITLE
bug/RCT-207-MissingHTTPStatusCodeInResults

### DIFF
--- a/validator/src/main/java/org/icann/rdapconformance/validator/ConnectionTracker.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/ConnectionTracker.java
@@ -349,15 +349,16 @@ public class ConnectionTracker {
      * @return The status code, or null if not available
      */
     public static Integer getMainStatusCode() {
-        ConnectionTracker tracker = getInstance();
-        ConnectionRecord mainConnection = tracker.getLastMainConnection();
+        ConnectionRecord mainConnection = getInstance().getLastMainConnection();
 
-        if (mainConnection == null || mainConnection.getStatusCode() == 0 || mainConnection.getStatus() == null) {
-            return null;
+        if (mainConnection == null || mainConnection.getStatusCode() == ZERO || mainConnection.getStatus() == null) {
+            return ZERO; // force to zero
         }
 
+        // otherwise it's good and return it
         return mainConnection.getStatusCode();
     }
+
 
     @Override
     public synchronized String toString() {

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpRequest.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpRequest.java
@@ -82,9 +82,8 @@ public class RDAPHttpRequest {
     }
 
     public static HttpResponse<String> makeRequest(URI originalUri, int timeoutSeconds, String method, boolean isMain) throws Exception {
-        return makeRequest(originalUri, timeoutSeconds, method, false, true);
+        return makeRequest(originalUri, timeoutSeconds, method, isMain, true);
     }
-
 
     public static HttpResponse<String> makeRequest(URI originalUri, int timeoutSeconds, String method, boolean isMain, boolean canRecordError) throws Exception {
         if (originalUri == null) {

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidationResultFileTest.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidationResultFileTest.java
@@ -285,7 +285,7 @@ public class RDAPValidationResultFileTest {
         RDAPValidatorResultsImpl results = RDAPValidatorResultsImpl.getInstance();
         results.clear();
 
-        // add them going in different -- but the statusCodeFromCurrent wlill never let it be null. It will zero it out
+        // add them going in different -- but the statusCodeFromCurrent will never let it be null. It will zero it out
         results.add(RDAPValidationResult.builder().code(1001).httpStatusCode(null).build());
         results.add(RDAPValidationResult.builder().code(1002).httpStatusCode(0).build());
 

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidationResultFileTest.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidationResultFileTest.java
@@ -284,15 +284,17 @@ public class RDAPValidationResultFileTest {
     public void testNullAndZeroStatusCodesAreEquivalent() {
         RDAPValidatorResultsImpl results = RDAPValidatorResultsImpl.getInstance();
         results.clear();
+
+        // add them going in different -- but the statusCodeFromCurrent wlill never let it be null. It will zero it out
         results.add(RDAPValidationResult.builder().code(1001).httpStatusCode(null).build());
         results.add(RDAPValidationResult.builder().code(1002).httpStatusCode(0).build());
 
         String output = results.analyzeResultsWithStatusCheck();
 
         // Both results should be in output
-        assertTrue(output.contains("code=1001, httpStatusCode=null"));
+        assertTrue(output.contains("code=1001, httpStatusCode=0"));
         assertTrue(output.contains("code=1002, httpStatusCode=0"));
-        // Should not generate -13018 error since null and 0 are considered equivalent
+        // Should not generate -13018 error since we have same status codes (0 vs 0)
         assertFalse(results.getAll().stream().anyMatch(r -> r.getCode() == -13018));
     }
 


### PR DESCRIPTION
CHANGE:
Set main connection to return ZERO if not set - fixes the null problem (don't ever return null there 🙄 
Pass isMain into makeRequest ... this was incorrectly set to false
Redo test for null/zero testing in the results
