### PR TITLE
feat/RCT-53: rdapResponseProfile_2_4_6 validation

### DIFF
--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/ResponseValidation2Dot4Dot6_2024.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/ResponseValidation2Dot4Dot6_2024.java
@@ -1,0 +1,143 @@
+package org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain;
+
+import java.util.Set;
+import org.icann.rdapconformance.validator.configuration.RDAPValidatorConfiguration;
+import org.icann.rdapconformance.validator.workflow.profile.ProfileJsonValidation;
+import org.icann.rdapconformance.validator.workflow.rdap.RDAPDatasetService;
+import org.icann.rdapconformance.validator.workflow.rdap.RDAPQueryType;
+import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidationResult;
+import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidatorResults;
+import org.icann.rdapconformance.validator.workflow.rdap.dataset.model.RegistrarId;
+import org.icann.rdapconformance.validator.workflow.rdap.dataset.model.RegistrarId.Record;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class ResponseValidation2Dot4Dot6_2024 extends ProfileJsonValidation {
+
+    private static final Logger logger = LoggerFactory.getLogger(ResponseValidation2Dot4Dot6_2024.class);
+
+    private final RDAPQueryType queryType;
+    private final RDAPValidatorConfiguration config;
+    private final RDAPDatasetService datasetService;
+
+    public ResponseValidation2Dot4Dot6_2024(String rdapResponse,
+        RDAPValidatorResults results,
+        RDAPDatasetService datasetService,
+        RDAPQueryType queryType,
+        RDAPValidatorConfiguration config) {
+        super(rdapResponse, results);
+        this.datasetService = datasetService;
+        this.queryType = queryType;
+        this.config = config;
+    }
+
+
+    @Override
+    public String getGroupName() {
+        return "rdapResponseProfile_2_4_6_Validation";
+    }
+
+    @Override
+    public boolean doValidate() {
+        Set<String> registrarEntitiesJsonPointers = getPointerFromJPath(
+            "$.entities[?(@.roles contains 'registrar')].links[?(@.rel == 'about')]");
+
+        if (registrarEntitiesJsonPointers.isEmpty()) {
+            results.add(RDAPValidationResult.builder()
+                .code(-47700)
+                .value(getResultValue(getPointerFromJPath("$.entities[?(@.roles contains 'registrar')]")))
+                .message(
+                    "A domain must have link to the RDAP base URL of the registrar.")
+                .build());
+
+            return false;
+        }
+
+        String linkPointer = registrarEntitiesJsonPointers.iterator().next();
+        String valuePointer = linkPointer + "/value";
+        String hrefPointer = linkPointer + "/href";
+        ;
+        String handlePointer = linkPointer.substring(0, linkPointer.lastIndexOf('/', linkPointer.lastIndexOf('/') - 1)) + "/handle";
+
+        boolean valueValid = true;
+
+        String value = null;
+        String href = null;
+
+        Object obj = jsonObject.query(valuePointer);
+        if (obj != null) {
+            value = obj.toString();
+        }
+        obj = jsonObject.query(hrefPointer);
+        if (obj != null) {
+            href = obj.toString();
+        }
+
+        if (!this.config.getUri().toString().equals(value)) {
+            results.add(RDAPValidationResult.builder()
+                .code(-47701)
+                .value(getResultValue(linkPointer))
+                .message(
+                    "The link for registrar RDAP base URL does not have a link value of the request URL.")
+                .build());
+
+            valueValid = false;
+        }
+
+        if (href == null || !href.startsWith("https")) {
+            results.add(RDAPValidationResult.builder()
+                .code(-47702)
+                .value(getResultValue(linkPointer))
+                .message(
+                    "The registrar RDAP base URL must have an https scheme.")
+                .build());
+
+            // no need to validate the url if the protocol is wrong
+            return false;
+        }
+
+        String handle = null;
+        obj = jsonObject.query(handlePointer);
+        if (obj != null) {
+            handle = obj.toString();
+        }
+
+        return validRdapUrl(handle, href, linkPointer) && valueValid;
+    }
+
+    private boolean validRdapUrl(String handle, String href, String linkPointer) {
+        int id;
+
+        try {
+            id = Integer.parseInt(handle);
+        } catch (NullPointerException | NumberFormatException e) {
+            // this is covered by existing handle validation, so we just skip 47703 test here
+            logger.info("handle = [{}], is null or not a number, skip rdap url 47703 validation", handle);
+
+            return true;
+        }
+
+        RegistrarId registrarId = datasetService.get(RegistrarId.class);
+        Record record = registrarId.getById(id);
+        String rdapUrl = record.getRdapUrl();
+
+        if (href == null || !href.equals(rdapUrl)) {
+            results.add(RDAPValidationResult.builder()
+                .code(-47703)
+                .value(getResultValue(linkPointer))
+                .message(
+                    "The registrar base URL is not registered with IANA.")
+                .build());
+
+            return false;
+        }
+
+        return true;
+    }
+
+
+    @Override
+    public boolean doLaunch() {
+        return queryType.equals(RDAPQueryType.DOMAIN);
+    }
+}

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidator.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidator.java
@@ -259,6 +259,7 @@ public class RDAPValidator implements ValidatorWorkflow {
         validations.add(new ResponseValidation1Dot2_2_2024(query.getData(), results)); // clean
         validations.add(new ResponseValidation2Dot2_2024(query.getData(), results, queryTypeProcessor.getQueryType())); // clean
         validations.add(new ResponseValidation2Dot2_1_2024(query.getData(), results, datasetService)); // clean
+        validations.add(new ResponseValidation2Dot4Dot6_2024(query.getData(), results, datasetService, queryTypeProcessor.getQueryType(), config)); // clean
         validations.add(new ResponseValidation2Dot7Dot1DotXAndRelated3And4_2024(query.getData(), results, queryTypeProcessor.getQueryType(), config)); // clean
         validations.add(new ResponseValidation2Dot7Dot3_2024(config, query.getData(), results, datasetService, queryTypeProcessor.getQueryType()));
         validations.add(new ResponseValidation2Dot9Dot1And2Dot9Dot2_2024(query.getData(), results, queryTypeProcessor.getQueryType())); // clean

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/ResponseValidation2Dot4Dot6_2024Test.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/ResponseValidation2Dot4Dot6_2024Test.java
@@ -1,0 +1,84 @@
+package org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain;
+
+import static org.mockito.Mockito.doReturn;
+
+import java.net.URI;
+import java.util.List;
+import org.icann.rdapconformance.validator.workflow.profile.ProfileValidation;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class ResponseValidation2Dot4Dot6_2024Test extends ResponseDomainValidationTestBase {
+
+    public ResponseValidation2Dot4Dot6_2024Test() {
+        super("rdapResponseProfile_2_4_6_Validation");
+    }
+
+    @BeforeMethod
+    public void setup() throws Exception {
+        JSONObject link = new JSONObject();
+        link.put("href", "https://example.com/");
+        link.put("value", "https://icann.org/wicf");
+        link.put("rel", "about");
+        link.put("type", "text/html");
+        JSONArray links = new JSONArray();
+        links.put(link);
+
+        jsonObject
+            .getJSONArray("entities")
+            .getJSONObject(0)
+            .put("links", links);
+
+        doReturn(new URI("https://icann.org/wicf")).when(config).getUri();
+    }
+
+
+    @Override
+    public ProfileValidation getProfileValidation() {
+        return new ResponseValidation2Dot4Dot6_2024(jsonObject.toString(), results, datasets, queryType, config);
+    }
+
+    @Test
+    @Override
+    public void testValidate_ok() {
+        validate();
+    }
+
+    @Test
+    public void testValidate_NoLinkWithRelIsAbout_AddResults47700() throws Exception {
+        removeKey("$['entities'][0]['links']");
+        validate(-47700,
+            "#/entities/0:{\"objectClassName\":\"entity\",\"publicIds\":[{\"identifier\":\"292\",\"type\":\"IANA Registrar ID\"}],\"vcardArray\":[\"vcard\","
+                + "[[\"version\",{},\"text\",\"4.0\"],[\"fn\",{},\"text\",\"Example Inc.\"]]],\"entities\":[{\"objectClassName\":\"entity\",\"vcardArray\":[\"vcard\","
+                + "[[\"version\",{},\"text\",\"4.0\"],[\"fn\",{},\"text\",\"\"],[\"tel\",{\"type\":\"voice\"},\"uri\",\"tel:+1.9999999999\"],"
+                + "[\"email\",{},\"text\",\"abusecomplaints@example.com\"],[\"adr\",{\"type\":\"work\"},\"text\",[\"\",\"Suite 1234\",\"4321 Rue Somewhere\","
+                + "\"Quebec\",\"QC\",\"G1V 2M2\",\"\"]]]],\"roles\":[\"abuse\"],\"handle\":\"292\"}],\"roles\":[\"registrar\"],\"handle\":\"292\"}",
+            "A domain must have link to the RDAP base URL of the registrar.");
+    }
+
+    @Test
+    public void testValidate_ValueDifferentFromRequest_AddResults47701() {
+        replaceValue("$['entities'][0]['links'][0]['value']", "https://localhost/");
+        validate(-47701,
+            "#/entities/0/links/0:{\"rel\":\"about\",\"href\":\"https://example.com/\",\"type\":\"text/html\",\"value\":\"https://localhost/\"}",
+            "The link for registrar RDAP base URL does not have a link value of the request URL.");
+    }
+
+    @Test
+    public void testValidate_HrefNotHttps_AddResults47702() {
+        replaceValue("$['entities'][0]['links'][0]['href']", "http://localhost/");
+        validate(-47702,
+            "#/entities/0/links/0:{\"rel\":\"about\",\"href\":\"http://localhost/\",\"type\":\"text/html\",\"value\":\"https://icann.org/wicf\"}",
+            "The registrar RDAP base URL must have an https scheme.");
+    }
+
+    @Test
+    public void testValidate_HrefNotRDAPBaseURL_AddResults47703() {
+        replaceValue("$['entities'][0]['links'][0]['href']", "https://localhost/");
+        validate(-47703,
+            "#/entities/0/links/0:{\"rel\":\"about\",\"href\":\"https://localhost/\",\"type\":\"text/html\",\"value\":\"https://icann.org/wicf\"}",
+            "The registrar base URL is not registered with IANA.");
+    }
+}


### PR DESCRIPTION
Verify that the domain object has one entity with the role “registrar” with one link object in the links array with a rel property of the string “about”.

With the link object above, validate that it contains a value property that is a string of the URL used to query for this response.

With the link object above, validate the href property contains an URL with the “https” scheme.

With the handle of the “registrar” entity, verify that the href property of the link object above matches one of the base URLs in the registrarId data set.

https://icann-jira.atlassian.net/browse/RCT-53