### PR TITLE
Remove static help text from Docker entrypoint

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,13 +1,9 @@
 #!/bin/sh
 
+RCT_VERSION="$(xq -x //rdap-conformance.version pom.xml)"
+
 help() {
-    cat << END
-Arguments:
-  [--timeout=<timeout>]
-  [[--use-rdap-profile-february-2019]
-  ([--gtld-registrar] | [--gtld-registry [--thin]])]
-  RDAP_URI
-END
+  java -jar "tool/target/rdapct-${RCT_VERSION}.jar" --help
   exit 0
 }
 
@@ -18,8 +14,6 @@ for arg in "$@" ; do
     help
   fi
 done
-
-RCT_VERSION="$(xq -x //rdap-conformance.version pom.xml)"
 
 java -jar "tool/target/rdapct-${RCT_VERSION}.jar" -c tool/bin/rdapct_config.json --use-local-datasets "$@" 1>&2
 


### PR DESCRIPTION
## Problem
The Docker entrypoint script contained a static help message that was incomplete and didn't reflect all available command-line options of the RDAP Conformance Tool. This could be confusing for users who expect to see all available options when running `docker run --rm rdapct -- --help`.

## Changes Made
- Removed the static help text from `docker-entrypoint.sh`
- Modified the help function to call the actual RDAP Conformance Tool with `--help` parameter
- Moved the version extraction to the top of the script for better organization

## Before
Running `docker run --rm rdapct -- --help` would show:
```
Arguments:
  [--timeout=<timeout>]
  [[--use-rdap-profile-february-2019]
  ([--gtld-registrar] | [--gtld-registry [--thin]])]
  RDAP_URI
```

## After
Now running `docker run --rm rdapct -- --help` shows the full help output:
```
Usage: rdap-conformance-tool [-hvV] [--additional-conformance-queries]
                             [--no-ipv4-queries] [--no-ipv6-queries]
                             [--use-local-datasets] -c=<configurationFile>
                             [--maximum-redirects=<maxRedirects>]
                             [--timeout=<timeout>]
                             [([[--use-rdap-profile-february-2019] |
                             [--use-rdap-profile-february-2024]]
                             ([--gtld-registrar] | [--gtld-registry
                             [--thin]]))] RDAP_URI
      RDAP_URI               The URI to be tested
      --additional-conformance-queries
                             Additional queries '/help' and 'not-a-domain.
                               invalid' to be issued
  -c, --config=<configurationFile>
                             Definition file
      --gtld-registrar       Validate the response as coming from a gTLD
                               registrar
      --gtld-registry        Validate the response as coming from a gTLD
                               registry
  -h, --help                 Show this help message and exit.
      --maximum-redirects=<maxRedirects>
                             Maximum number of redirects to follow
      --no-ipv4-queries      No queries over IPv4 are to be issued
      --no-ipv6-queries      No queries over IPv6 are to be issued
      --thin                 The TLD uses the thin model
      --timeout=<timeout>    Timeout for connecting to the server
      --use-local-datasets   Use locally-persisted datasets
      --use-rdap-profile-february-2019
                             Use RDAP Profile February 2019
      --use-rdap-profile-february-2024
                             Use RDAP Profile February 2024
  -v, --verbose              display all logs
  -V, --version              Print version information and exit.
```

## Testing
The changes have been tested by building the Docker image locally and verifying the help output.

## Notes
- This change ensures users always see the complete and up-to-date help information
- The help text will automatically stay in sync with future versions of the RDAP Conformance Tool
- No changes to the actual functionality of the tool were made
