### PR TITLE
Align ResponseValidation2Dot4Dot6_2024 with the RDAP Response Profile

### DIFF
--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidator.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidator.java
@@ -254,7 +254,7 @@ public class RDAPValidator implements ValidatorWorkflow {
         validations.add(new ResponseValidation1Dot2_2_2024(rdapResponseData, results)); // clean
         validations.add(new ResponseValidation2Dot2_2024(rdapResponseData, results, queryType)); // clean
         validations.add(new ResponseValidation2Dot2_1_2024(rdapResponseData, results, datasetService)); // clean
-        validations.add(new ResponseValidation2Dot4Dot6_2024(rdapResponseData, results, datasetService,queryType, config)); // clean
+        validations.add(new ResponseValidation2Dot4Dot6_2024(rdapResponseData, results, datasetService,queryType)); // clean
         validations.add(new ResponseValidation2Dot7Dot1DotXAndRelated3And4_2024(rdapResponseData, results, queryType, config)); // clean
         validations.add(new ResponseValidation2Dot7Dot3_2024(config, rdapResponseData, results, datasetService, queryType));
         validations.add(new ResponseValidation2Dot7Dot5Dot1_2024(rdapResponseData, results)); // clean

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/ResponseValidation2Dot4Dot6_2024Test.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/ResponseValidation2Dot4Dot6_2024Test.java
@@ -1,9 +1,5 @@
 package org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain;
 
-import static org.mockito.Mockito.doReturn;
-
-import java.net.URI;
-import java.util.List;
 import org.icann.rdapconformance.validator.workflow.profile.ProfileValidation;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -19,8 +15,8 @@ public class ResponseValidation2Dot4Dot6_2024Test extends ResponseDomainValidati
     @BeforeMethod
     public void setup() throws Exception {
         JSONObject link = new JSONObject();
-        link.put("href", "https://example.com/");
-        link.put("value", "https://icann.org/wicf");
+        link.put("href", "https://icann.org/wicf");
+        link.put("value", "https://example.com/");
         link.put("rel", "about");
         link.put("type", "text/html");
         JSONArray links = new JSONArray();
@@ -30,14 +26,12 @@ public class ResponseValidation2Dot4Dot6_2024Test extends ResponseDomainValidati
             .getJSONArray("entities")
             .getJSONObject(0)
             .put("links", links);
-
-        doReturn(new URI("https://icann.org/wicf")).when(config).getUri();
     }
 
 
     @Override
     public ProfileValidation getProfileValidation() {
-        return new ResponseValidation2Dot4Dot6_2024(jsonObject.toString(), results, datasets, queryType, config);
+        return new ResponseValidation2Dot4Dot6_2024(jsonObject.toString(), results, datasets, queryType);
     }
 
     @Test
@@ -59,26 +53,18 @@ public class ResponseValidation2Dot4Dot6_2024Test extends ResponseDomainValidati
     }
 
     @Test
-    public void testValidate_ValueDifferentFromRequest_AddResults47701() {
-        replaceValue("$['entities'][0]['links'][0]['value']", "https://localhost/");
-        validate(-47701,
-            "#/entities/0/links/0:{\"rel\":\"about\",\"href\":\"https://example.com/\",\"type\":\"text/html\",\"value\":\"https://localhost/\"}",
-            "The link for registrar RDAP base URL does not have a link value of the request URL.");
-    }
-
-    @Test
     public void testValidate_HrefNotHttps_AddResults47702() {
-        replaceValue("$['entities'][0]['links'][0]['href']", "http://localhost/");
-        validate(-47702,
-            "#/entities/0/links/0:{\"rel\":\"about\",\"href\":\"http://localhost/\",\"type\":\"text/html\",\"value\":\"https://icann.org/wicf\"}",
+        replaceValue("$['entities'][0]['links'][0]['value']", "http://localhost/");
+        validate(-47701,
+            "#/entities/0/links/0:{\"rel\":\"about\",\"href\":\"https://icann.org/wicf\",\"type\":\"text/html\",\"value\":\"http://localhost/\"}",
             "The registrar RDAP base URL must have an https scheme.");
     }
 
     @Test
     public void testValidate_HrefNotRDAPBaseURL_AddResults47703() {
-        replaceValue("$['entities'][0]['links'][0]['href']", "https://localhost/");
-        validate(-47703,
-            "#/entities/0/links/0:{\"rel\":\"about\",\"href\":\"https://localhost/\",\"type\":\"text/html\",\"value\":\"https://icann.org/wicf\"}",
+        replaceValue("$['entities'][0]['links'][0]['value']", "https://localhost/");
+        validate(-47702,
+            "#/entities/0/links/0:{\"rel\":\"about\",\"href\":\"https://icann.org/wicf\",\"type\":\"text/html\",\"value\":\"https://localhost/\"}",
             "The registrar base URL is not registered with IANA.");
     }
 }


### PR DESCRIPTION
From section 2.4.6:

> Registrar URL - The entity with the registrar role in the RDAP response
MUST contain a links member [RFC9083]. The links object MUST contain
the elements: value, identical to the the RDAP Base URL for the
Registrar as provided in the IANA “Registrar IDs” registry (i.e.,
https://www.iana.org/assignments/registrar-ids); rel:about, and href
containing the Registrar URL. Note: in cases where the Registry Operator
acts as sponsoring Registrar (e.g., IANA Registrar ID 9999), the href shall
contain a URL from the Registry.

I have removed the check for the request URL and switched the RDAP base URL validation to check the `value`.