### PR TITLE
Fix checks for the request URL in notices

### DIFF
--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/ResponseValidation2Dot10_2024.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/ResponseValidation2Dot10_2024.java
@@ -1,5 +1,6 @@
 package org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain;
 
+import org.icann.rdapconformance.validator.configuration.RDAPValidatorConfiguration;
 import org.icann.rdapconformance.validator.workflow.profile.ProfileJsonValidation;
 import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidationResult;
 import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidatorResults;
@@ -19,10 +20,12 @@ import java.util.Set;
 
 public class ResponseValidation2Dot10_2024 extends ProfileJsonValidation {
 
+    private final RDAPValidatorConfiguration config;
     private static final String NOT_FOUND = "not_found";
 
-    public ResponseValidation2Dot10_2024(String rdapResponse, RDAPValidatorResults results) {
+    public ResponseValidation2Dot10_2024(String rdapResponse, RDAPValidatorResults results, RDAPValidatorConfiguration config) {
         super(rdapResponse, results);
+        this.config = config;
     }
 
     private static final Logger logger = LoggerFactory.getLogger(ResponseValidation2Dot10_2024.class);
@@ -145,7 +148,7 @@ public class ResponseValidation2Dot10_2024 extends ProfileJsonValidation {
                 return false;
             }
 
-            if(!isValidURL(inaccuracyComplaintLink.get().value())) {
+            if(!inaccuracyComplaintLink.get().value().equalsIgnoreCase(this.config.getUri().toString())) {
                 results.add(RDAPValidationResult.builder()
                         .code(-46706)
                         .value(getResultValue(noticePointersValue))

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/ResponseValidation2Dot6Dot3_2024.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/ResponseValidation2Dot6Dot3_2024.java
@@ -147,15 +147,13 @@ public final class ResponseValidation2Dot6Dot3_2024 extends ProfileJsonValidatio
                 return false;
             }
 
-            if(isValidURL(statusLink.get().value())) {
-                if(!statusLink.get().value().equalsIgnoreCase(this.config.getUri().toString())) {
-                    results.add(RDAPValidationResult.builder()
-                            .code(-46606)
-                            .value(getResultValue(noticePointersValue))
-                            .message("The notice for Status Codes does not have a link value of the request URL.")
-                            .build());
-                    return false;
-                }
+            if(!statusLink.get().value().equalsIgnoreCase(this.config.getUri().toString())) {
+                results.add(RDAPValidationResult.builder()
+                        .code(-46606)
+                        .value(getResultValue(noticePointersValue))
+                        .message("The notice for Status Codes does not have a link value of the request URL.")
+                        .build());
+                return false;
             }
         }
 

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidator.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidator.java
@@ -280,7 +280,7 @@ public class RDAPValidator implements ValidatorWorkflow {
         validations.add(new TigValidation3Dot2_2024(rdapResponseData, results, config, queryType)); // clean
         validations.add(new TigValidation3Dot3And3Dot4_2024(rdapResponseData, results, config)); // clean
         validations.add(new ResponseValidation2Dot6Dot3_2024(rdapResponseData, results, config)); //clean
-        validations.add(new ResponseValidation2Dot10_2024(rdapResponseData, results)); // clean
+        validations.add(new ResponseValidation2Dot10_2024(rdapResponseData, results, config)); // clean
 
         // Conditionally add validations that require network connections
         if (config.isNetworkEnabled()) {

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/ResponseValidation2Dot10_2024Test.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/ResponseValidation2Dot10_2024Test.java
@@ -1,5 +1,6 @@
 package org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain;
 
+import org.icann.rdapconformance.validator.configuration.RDAPValidatorConfiguration;
 import org.icann.rdapconformance.validator.workflow.profile.ProfileJsonValidationTestBase;
 import org.icann.rdapconformance.validator.workflow.profile.ProfileValidation;
 import org.json.JSONArray;
@@ -7,7 +8,11 @@ import org.json.JSONObject;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
 import java.io.IOException;
+import java.net.URI;
 
 public class ResponseValidation2Dot10_2024Test extends ProfileJsonValidationTestBase {
 
@@ -34,13 +39,19 @@ public class ResponseValidation2Dot10_2024Test extends ProfileJsonValidationTest
     @BeforeMethod
     public void setUp() throws IOException {
         super.setUp();
+        URI uri = URI.create("https://rdap.cscglobal.com/dbs/rdap-api/v1/domain/cscglobal.com");
+        doReturn(uri).when(config).getUri();
+
+        config = mock(RDAPValidatorConfiguration.class);
+        doReturn(uri).when(config).getUri();
     }
 
     @Override
     public ProfileValidation getProfileValidation() {
         return new ResponseValidation2Dot10_2024(
                 jsonObject.toString(),
-                results);
+                results,
+                this.config);
     }
 
     @Test


### PR DESCRIPTION
- ResponseValidation2Dot10_2024: Actually check if the link value is the request URL.
- ResponseValidation2Dot6Dot3_2024: Remove check for valid URL, no need when checking if it matches request URL.