### PR TITLE
Revert "feat/RCT-208-error-registrar-9999 (#199)"

### DIFF
--- a/validator/src/main/resources/json-schema/rdap_domain.json
+++ b/validator/src/main/resources/json-schema/rdap_domain.json
@@ -99,7 +99,7 @@
   "stdRdapStatusValidation": -12211,
   "stdRdapPublicIdsValidation": -12212,
   "stdRdapRemarksValidation": -12213,
-  "stdRdapLinksValidation": -10610,
+  "stdRdapLinksValidation": -12214,
   "stdRdapPort43WhoisServerValidation": -12215,
   "stdRdapEventsValidation": -12216,
   "stdRdapNoticesRemarksValidation": -12217,

--- a/validator/src/test/java/org/icann/rdapconformance/validator/schemavalidator/SchemaValidatorDomainTest.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/schemavalidator/SchemaValidatorDomainTest.java
@@ -81,7 +81,7 @@ public class SchemaValidatorDomainTest extends SchemaValidatorObjectTest {
 
   @Test
   public void stdRdapLinksValidation() {
-    stdRdapLinksValidation(-10610);
+    stdRdapLinksValidation(-12214);
   }
 
   @Test


### PR DESCRIPTION
This reverts commit 5acaaea6daa1c0fbdd04acb5d70a68a4ab9048bd.

This original ticket rct-208 is invalid. It was the correct behavior according to the specs. 

In that case, 2 error codes should be in the report: 10610: href is missing as well as 12214: stdRdapLinksValidation failure.

Please refer to the section 7.3.1.15 of the original spects for detail. 

