### PR TITLE
fix/RCT-278-missing-errorCode

### DIFF
--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
@@ -235,6 +235,7 @@ public class RDAPHttpQuery implements RDAPQuery {
         if (config.useRdapProfileFeb2024()) {
             if (!validateIfContainsErrorCode(httpStatusCode, rdapResponse)) {
                 addErrorToResultsFile(-12107, rdapResponse, "The errorCode value is required in an error response.");
+                isQuerySuccessful = false;
             }
         }
 


### PR DESCRIPTION
CHANGE: RDAP Validation Tool triggers incorrect domain object rules when testing error response with Missing errorCode Field