### PR TITLE
bug/RCT-289-SSLTestFailing 

### DIFF
--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/tig_section/general/DefaultSSLValidator.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/tig_section/general/DefaultSSLValidator.java
@@ -1,0 +1,110 @@
+package org.icann.rdapconformance.validator.workflow.profile.tig_section.general;
+
+import static org.icann.rdapconformance.validator.CommonUtils.TIMEOUT_IN_5SECS;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.List;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocket;
+import org.icann.rdapconformance.validator.DNSCacheResolver;
+import org.icann.rdapconformance.validator.NetworkInfo;
+import org.icann.rdapconformance.validator.NetworkProtocol;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Default implementation of SSLValidator that performs actual SSL connections
+ * and validation against real servers.
+ */
+public class DefaultSSLValidator implements SSLValidator {
+    
+    private static final Logger logger = LoggerFactory.getLogger(DefaultSSLValidator.class);
+    
+    @Override
+    public SSLValidationResult validateSSL(String hostname, int port) {
+        try {
+            SSLContext sslContext = SSLContext.getDefault();
+            
+            // Resolve the hostname to an IP address
+            InetAddress ipAddress = resolveHostname(hostname);
+            if (ipAddress == null) {
+                return SSLValidationResult.failure(
+                    "Cannot resolve correct v4 or v6 host address for " + hostname, null);
+            }
+            
+            // Create socket connection and get enabled protocols
+            List<String> enabledProtocols = getEnabledProtocols(sslContext, hostname, ipAddress, port);
+            
+            // TLS 1.2 cipher suite validation is now handled through the public method
+            
+            return SSLValidationResult.success(enabledProtocols);
+            
+        } catch (NoSuchAlgorithmException e) {
+            logger.info("Cannot create SSL context", e);
+            return SSLValidationResult.failure("Cannot create SSL context", e);
+        } catch (IOException e) {
+            logger.info("Error during SSL connection setup", e);
+            return SSLValidationResult.failure("Error during SSL connection setup", e);
+        }
+    }
+    
+    private InetAddress resolveHostname(String hostname) {
+        if (NetworkInfo.getNetworkProtocol() == NetworkProtocol.IPv6) {
+            InetAddress ipAddress = DNSCacheResolver.getFirstV6Address(hostname);
+            logger.info("Using IPv6 address {} for host {}", ipAddress, hostname);
+            return ipAddress;
+        } else {
+            InetAddress ipAddress = DNSCacheResolver.getFirstV4Address(hostname);
+            logger.info("Using IPv4 address {} for host {}", ipAddress, hostname);
+            return ipAddress;
+        }
+    }
+    
+    private List<String> getEnabledProtocols(SSLContext sslContext, String hostname, 
+                                           InetAddress ipAddress, int port) throws IOException {
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress(ipAddress, port), TIMEOUT_IN_5SECS);
+            logger.info("Connected to {} ({})", hostname, ipAddress.getHostAddress());
+            
+            try (SSLSocket sslSocket = (SSLSocket) sslContext.getSocketFactory()
+                    .createSocket(socket, hostname, port, true)) {
+                sslSocket.startHandshake();
+                List<String> enabledProtocols = Arrays.asList(sslSocket.getEnabledProtocols());
+                logger.debug("Enabled protocols: {}", enabledProtocols);
+                return enabledProtocols;
+            }
+        }
+    }
+    
+    @Override
+    public CipherValidationResult validateTLS12CipherSuites(String hostname, int port) {
+        try {
+            SSLContext sslContext = SSLContext.getDefault();
+            
+            try (SSLSocket sslSocket = (SSLSocket) sslContext.getSocketFactory()
+                    .createSocket(hostname, port)) {
+                sslSocket.setEnabledProtocols(new String[]{"TLSv1.2"});
+                sslSocket.startHandshake();
+                SSLSession sslSession = sslSocket.getSession();
+                
+                String protocol = sslSession.getProtocol();
+                String cipher = sslSession.getCipherSuite();
+                logger.info("cipher for protocol {} is {}", protocol, cipher);
+                
+                return CipherValidationResult.success(protocol, cipher);
+            }
+        } catch (NoSuchAlgorithmException e) {
+            logger.info("Cannot create SSL context for TLS 1.2 cipher validation", e);
+            return CipherValidationResult.failure("Cannot create SSL context for TLS 1.2 cipher validation", e);
+        } catch (IOException e) {
+            logger.info("Connection error during TLS 1.2 cipher validation", e);
+            return CipherValidationResult.failure("Connection error during TLS 1.2 cipher validation", e);
+        }
+    }
+}

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/tig_section/general/SSLValidator.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/tig_section/general/SSLValidator.java
@@ -1,0 +1,121 @@
+package org.icann.rdapconformance.validator.workflow.profile.tig_section.general;
+
+import java.util.List;
+
+/**
+ * Interface for SSL/TLS validation operations.
+ * This allows for easier testing by providing a mockable abstraction
+ * over the complex SSL socket operations.
+ */
+public interface SSLValidator {
+    
+    /**
+     * Validates the SSL/TLS configuration of a server.
+     * 
+     * @param hostname The hostname to connect to
+     * @param port The port to connect to
+     * @return SSLValidationResult containing the validation outcome.
+     *         This method will never return null - it always returns either a
+     *         success or failure result.
+     */
+    SSLValidationResult validateSSL(String hostname, int port);
+    
+    /**
+     * Validates TLS 1.2 cipher suites for a server.
+     * 
+     * @param hostname The hostname to connect to
+     * @param port The port to connect to
+     * @return CipherValidationResult containing the cipher validation outcome.
+     *         This method will never return null - it always returns either a
+     *         success or failure result.
+     */
+    CipherValidationResult validateTLS12CipherSuites(String hostname, int port);
+    
+    /**
+     * Result of SSL validation containing the protocols and cipher information.
+     */
+    class SSLValidationResult {
+        private final boolean successful;
+        private final List<String> enabledProtocols;
+        private final String errorMessage;
+        private final Exception exception;
+        
+        public SSLValidationResult(boolean successful, List<String> enabledProtocols, String errorMessage, Exception exception) {
+            this.successful = successful;
+            this.enabledProtocols = enabledProtocols;
+            this.errorMessage = errorMessage;
+            this.exception = exception;
+        }
+        
+        public static SSLValidationResult success(List<String> enabledProtocols) {
+            return new SSLValidationResult(true, enabledProtocols, null, null);
+        }
+        
+        public static SSLValidationResult failure(String errorMessage, Exception exception) {
+            return new SSLValidationResult(false, null, errorMessage, exception);
+        }
+        
+        public boolean isSuccessful() {
+            return successful;
+        }
+        
+        public List<String> getEnabledProtocols() {
+            return enabledProtocols;
+        }
+        
+        public String getErrorMessage() {
+            return errorMessage;
+        }
+        
+        public Exception getException() {
+            return exception;
+        }
+    }
+    
+    /**
+     * Result of cipher suite validation.
+     */
+    class CipherValidationResult {
+        private final boolean successful;
+        private final String cipherSuite;
+        private final String protocol;
+        private final String errorMessage;
+        private final Exception exception;
+        
+        public CipherValidationResult(boolean successful, String cipherSuite, String protocol, String errorMessage, Exception exception) {
+            this.successful = successful;
+            this.cipherSuite = cipherSuite;
+            this.protocol = protocol;
+            this.errorMessage = errorMessage;
+            this.exception = exception;
+        }
+        
+        public static CipherValidationResult success(String protocol, String cipherSuite) {
+            return new CipherValidationResult(true, cipherSuite, protocol, null, null);
+        }
+        
+        public static CipherValidationResult failure(String errorMessage, Exception exception) {
+            return new CipherValidationResult(false, null, null, errorMessage, exception);
+        }
+        
+        public boolean isSuccessful() {
+            return successful;
+        }
+        
+        public String getCipherSuite() {
+            return cipherSuite;
+        }
+        
+        public String getProtocol() {
+            return protocol;
+        }
+        
+        public String getErrorMessage() {
+            return errorMessage;
+        }
+        
+        public Exception getException() {
+            return exception;
+        }
+    }
+}

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/tig_section/general/TigValidation1Dot5_2024Test.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/tig_section/general/TigValidation1Dot5_2024Test.java
@@ -5,16 +5,12 @@ import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertTrue;
 
 import java.io.IOException;
-import java.net.Socket;
 import java.net.URI;
 import java.net.http.HttpResponse;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSession;
-import javax.net.ssl.SSLSocket;
-import javax.net.ssl.SSLSocketFactory;
+import java.util.Arrays;
+import java.util.List;
 import org.icann.rdapconformance.validator.configuration.RDAPValidatorConfiguration;
 import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidatorResults;
-import org.mockito.MockedStatic;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -23,6 +19,7 @@ public class TigValidation1Dot5_2024Test {
     private HttpResponse<String> httpResponse;
     private RDAPValidatorConfiguration config;
     private RDAPValidatorResults results;
+    private SSLValidator mockSSLValidator;
     private TigValidation1Dot5_2024 validation;
 
     @BeforeMethod
@@ -30,91 +27,174 @@ public class TigValidation1Dot5_2024Test {
         httpResponse = mock(HttpResponse.class);
         config = mock(RDAPValidatorConfiguration.class);
         results = mock(RDAPValidatorResults.class);
+        mockSSLValidator = mock(SSLValidator.class);
 
         when(config.getUri()).thenReturn(URI.create("https://example.com"));
 
-        validation = new TigValidation1Dot5_2024(httpResponse, config, results);
+        // Set up default mock behavior for SSL cipher validation to prevent NPE
+        SSLValidator.CipherValidationResult defaultCipherResult = 
+            SSLValidator.CipherValidationResult.success("TLSv1.2", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
+        when(mockSSLValidator.validateTLS12CipherSuites(anyString(), anyInt())).thenReturn(defaultCipherResult);
+
+        // Use constructor that allows dependency injection
+        validation = new TigValidation1Dot5_2024(httpResponse, config, results, mockSSLValidator);
+    }
+
+    @Test
+    public void testDoValidate_NonHttpsUri() throws Exception {
+        // Test with HTTP (non-HTTPS) URI - should return true without SSL validation
+        when(httpResponse.uri()).thenReturn(URI.create("http://example.com"));
+
+        boolean isValid = validation.doValidate();
+        assertTrue("Validation should pass for non-HTTPS URI", isValid);
+        
+        // Verify no SSL validation was performed
+        verify(mockSSLValidator, never()).validateSSL(anyString(), anyInt());
+        verify(results, never()).add(any());
+    }
+
+    @Test
+    public void testGetGroupName() {
+        String groupName = validation.getGroupName();
+        assertTrue("Group name should be tigSection_1_5_Validation", 
+                   "tigSection_1_5_Validation".equals(groupName));
     }
 
     @Test
     public void testDoValidate_ValidTLSProtocols() throws Exception {
-        SSLContext sslContext = mock(SSLContext.class);
-        SSLSocketFactory sslSocketFactory = mock(SSLSocketFactory.class);
-        SSLSocket sslSocket = mock(SSLSocket.class);
-        SSLSession sslSession = mock(SSLSession.class);
+        // Test with valid TLS protocols - should return true
+        when(httpResponse.uri()).thenReturn(URI.create("https://example.com"));
+        
+        List<String> validProtocols = Arrays.asList("TLSv1.2", "TLSv1.3");
+        SSLValidator.SSLValidationResult successResult = SSLValidator.SSLValidationResult.success(validProtocols);
+        when(mockSSLValidator.validateSSL("example.com", 443)).thenReturn(successResult);
+        
+        // Mock cipher validation for TLS 1.2
+        SSLValidator.CipherValidationResult cipherResult = 
+            SSLValidator.CipherValidationResult.success("TLSv1.2", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
+        when(mockSSLValidator.validateTLS12CipherSuites("example.com", 443)).thenReturn(cipherResult);
 
-        when(sslContext.getSocketFactory()).thenReturn(sslSocketFactory);
-
-        // Mock both createSocket() overloads
-        when(sslSocketFactory.createSocket(any(Socket.class), anyString(), anyInt(), anyBoolean())).thenReturn(sslSocket);
-        when(sslSocketFactory.createSocket(anyString(), anyInt())).thenReturn(sslSocket);
-
-        when(sslSocket.getEnabledProtocols()).thenReturn(new String[]{"TLSv1.2", "TLSv1.3"});
-        when(sslSocket.getSession()).thenReturn(sslSession);
-        when(sslSession.getCipherSuite()).thenReturn("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
-        when(sslSession.getProtocol()).thenReturn("TLSv1.2");
-
-        try (MockedStatic<SSLContext> mockedStatic = mockStatic(SSLContext.class)) {
-            mockedStatic.when(SSLContext::getDefault).thenReturn(sslContext);
-
-            doNothing().when(sslSocket).startHandshake();
-            when(httpResponse.uri()).thenReturn(URI.create("https://example.com"));
-
-            boolean isValid = validation.doValidate();
-            assertTrue("Validation should be successful for valid TLS protocols", isValid);
-        }
-    }
-
-    @Test
-    public void testDoValidate_ValidTLSProtocolButBadCipher() throws Exception {
-        SSLContext sslContext = mock(SSLContext.class);
-        SSLSocketFactory sslSocketFactory = mock(SSLSocketFactory.class);
-        SSLSocket sslSocket = mock(SSLSocket.class);
-        SSLSession sslSession = mock(SSLSession.class);
-
-        when(sslContext.getSocketFactory()).thenReturn(sslSocketFactory);
-
-        // Mock both createSocket() overloads
-        when(sslSocketFactory.createSocket(any(Socket.class), anyString(), anyInt(), anyBoolean())).thenReturn(sslSocket);
-        when(sslSocketFactory.createSocket(anyString(), anyInt())).thenReturn(sslSocket);
-
-        when(sslSocket.getEnabledProtocols()).thenReturn(new String[]{"TLSv1.2", "TLSv1.3"});
-        when(sslSocket.getSession()).thenReturn(sslSession);
-        when(sslSession.getCipherSuite()).thenReturn("TLS_AES_128_GCM_SHA256");
-        when(sslSession.getProtocol()).thenReturn("TLSv1.2");
-
-        try (MockedStatic<SSLContext> mockedStatic = mockStatic(SSLContext.class)) {
-            mockedStatic.when(SSLContext::getDefault).thenReturn(sslContext);
-
-            doNothing().when(sslSocket).startHandshake();
-            when(httpResponse.uri()).thenReturn(URI.create("https://example.com"));
-
-            boolean isValid = validation.doValidate();
-            assertFalse("Validation should not be successful for valid TLS protocol but a cipher", isValid);
-        }
+        boolean isValid = validation.doValidate();
+        assertTrue("Validation should pass for valid TLS protocols", isValid);
+        
+        verify(mockSSLValidator).validateSSL("example.com", 443);
+        verify(results, never()).add(any()); // No errors should be added
     }
 
     @Test
     public void testDoValidate_InvalidTLSProtocol() throws Exception {
-        SSLContext sslContext = mock(SSLContext.class);
-        SSLSocketFactory sslSocketFactory = mock(SSLSocketFactory.class);
-        SSLSocket sslSocket = mock(SSLSocket.class);
+        // Test with invalid TLS protocol - should return false and add error
+        when(httpResponse.uri()).thenReturn(URI.create("https://example.com"));
+        
+        List<String> invalidProtocols = Arrays.asList("TLSv1.1"); // Invalid protocol
+        SSLValidator.SSLValidationResult successResult = SSLValidator.SSLValidationResult.success(invalidProtocols);
+        when(mockSSLValidator.validateSSL("example.com", 443)).thenReturn(successResult);
 
-        when(sslContext.getSocketFactory()).thenReturn(sslSocketFactory);
-        when(sslSocketFactory.createSocket(any(Socket.class), anyString(), anyInt(), anyBoolean())).thenReturn(sslSocket);
-        when(sslSocket.getEnabledProtocols()).thenReturn(new String[]{"TLSv1.1"});
-        when(sslSocket.getSession()).thenReturn(mock(SSLSession.class));
+        boolean isValid = validation.doValidate();
+        assertFalse("Validation should fail for invalid TLS protocol", isValid);
+        
+        verify(mockSSLValidator).validateSSL("example.com", 443);
+        verify(results).add(any()); // Error should be added for invalid protocol
+    }
 
-        try (MockedStatic<SSLContext> mockedStatic = mockStatic(SSLContext.class)) {
-            mockedStatic.when(SSLContext::getDefault).thenReturn(sslContext);
+    @Test
+    public void testDoValidate_SSLValidationFailure() throws Exception {
+        // Test when SSL validation itself fails
+        when(httpResponse.uri()).thenReturn(URI.create("https://example.com"));
+        
+        SSLValidator.SSLValidationResult failureResult = 
+            SSLValidator.SSLValidationResult.failure("Connection failed", new IOException("Connection timeout"));
+        when(mockSSLValidator.validateSSL("example.com", 443)).thenReturn(failureResult);
 
-            doNothing().when(sslSocket).startHandshake();
+        boolean isValid = validation.doValidate();
+        assertFalse("Validation should fail when SSL validation fails", isValid);
+        
+        verify(mockSSLValidator).validateSSL("example.com", 443);
+        // No results should be added when SSL validation itself fails
+        verify(results, never()).add(any());
+    }
 
-            when(httpResponse.uri()).thenReturn(URI.create("https://example.com"));
-            boolean isValid = validation.doValidate();
+    @Test
+    public void testDoValidate_MixedValidAndInvalidProtocols() throws Exception {
+        // Test with mixed valid and invalid protocols
+        when(httpResponse.uri()).thenReturn(URI.create("https://example.com"));
+        
+        List<String> mixedProtocols = Arrays.asList("TLSv1.1", "TLSv1.2", "TLSv1.3"); // One invalid, two valid
+        SSLValidator.SSLValidationResult successResult = SSLValidator.SSLValidationResult.success(mixedProtocols);
+        when(mockSSLValidator.validateSSL("example.com", 443)).thenReturn(successResult);
+        
+        // Mock cipher validation for TLS 1.2 (since TLS 1.2 is present)
+        SSLValidator.CipherValidationResult cipherResult = 
+            SSLValidator.CipherValidationResult.success("TLSv1.2", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
+        when(mockSSLValidator.validateTLS12CipherSuites("example.com", 443)).thenReturn(cipherResult);
 
-            assertFalse(isValid);
-            verify(results).add(any());
-        }
+        boolean isValid = validation.doValidate();
+        assertFalse("Validation should fail when any invalid protocol is present", isValid);
+        
+        verify(mockSSLValidator).validateSSL("example.com", 443);
+        verify(results).add(any()); // Error should be added for the invalid protocol
+    }
+    
+    @Test
+    public void testDoValidate_ValidTLS12CipherSuite() throws Exception {
+        // Test with TLS 1.2 and valid cipher suite
+        when(httpResponse.uri()).thenReturn(URI.create("https://example.com"));
+        
+        List<String> protocols = Arrays.asList("TLSv1.2");
+        SSLValidator.SSLValidationResult successResult = SSLValidator.SSLValidationResult.success(protocols);
+        when(mockSSLValidator.validateSSL("example.com", 443)).thenReturn(successResult);
+        
+        SSLValidator.CipherValidationResult cipherResult = 
+            SSLValidator.CipherValidationResult.success("TLSv1.2", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
+        when(mockSSLValidator.validateTLS12CipherSuites("example.com", 443)).thenReturn(cipherResult);
+
+        boolean isValid = validation.doValidate();
+        assertTrue("Validation should pass for valid TLS 1.2 cipher suite", isValid);
+        
+        verify(mockSSLValidator).validateSSL("example.com", 443);
+        verify(mockSSLValidator).validateTLS12CipherSuites("example.com", 443);
+        verify(results, never()).add(any()); // No errors should be added
+    }
+    
+    @Test
+    public void testDoValidate_InvalidTLS12CipherSuite() throws Exception {
+        // Test with TLS 1.2 and invalid cipher suite
+        when(httpResponse.uri()).thenReturn(URI.create("https://example.com"));
+        
+        List<String> protocols = Arrays.asList("TLSv1.2");
+        SSLValidator.SSLValidationResult successResult = SSLValidator.SSLValidationResult.success(protocols);
+        when(mockSSLValidator.validateSSL("example.com", 443)).thenReturn(successResult);
+        
+        SSLValidator.CipherValidationResult cipherResult = 
+            SSLValidator.CipherValidationResult.success("TLSv1.2", "TLS_RSA_WITH_AES_128_CBC_SHA"); // Invalid cipher
+        when(mockSSLValidator.validateTLS12CipherSuites("example.com", 443)).thenReturn(cipherResult);
+
+        boolean isValid = validation.doValidate();
+        assertFalse("Validation should fail for invalid TLS 1.2 cipher suite", isValid);
+        
+        verify(mockSSLValidator).validateSSL("example.com", 443);
+        verify(mockSSLValidator).validateTLS12CipherSuites("example.com", 443);
+        verify(results).add(any()); // Error should be added for invalid cipher
+    }
+    
+    @Test
+    public void testDoValidate_CipherValidationFailure() throws Exception {
+        // Test when cipher validation itself fails
+        when(httpResponse.uri()).thenReturn(URI.create("https://example.com"));
+        
+        List<String> protocols = Arrays.asList("TLSv1.2");
+        SSLValidator.SSLValidationResult successResult = SSLValidator.SSLValidationResult.success(protocols);
+        when(mockSSLValidator.validateSSL("example.com", 443)).thenReturn(successResult);
+        
+        SSLValidator.CipherValidationResult cipherResult = 
+            SSLValidator.CipherValidationResult.failure("Connection failed", new IOException("Timeout"));
+        when(mockSSLValidator.validateTLS12CipherSuites("example.com", 443)).thenReturn(cipherResult);
+
+        boolean isValid = validation.doValidate();
+        assertFalse("Validation should fail when cipher validation fails", isValid);
+        
+        verify(mockSSLValidator).validateSSL("example.com", 443);
+        verify(mockSSLValidator).validateTLS12CipherSuites("example.com", 443);
+        verify(results, never()).add(any()); // No results should be added when cipher validation itself fails
     }
 }


### PR DESCRIPTION
CHANGE:

New Files Created:
  - SSLValidator.java - Interface defining SSL validation contracts with result classes
  - DefaultSSLValidator.java - Implementation containing the original SSL validation logic from master

  Modified Files:
  - TigValidation1Dot5_2024.java:
    - Added SSLValidator dependency injection via constructor
    - Replaced inline SSL connection code with calls to SSLValidator methods
    - Extracted cipher validation logic to private helper method isValidTLS12Cipher()
    - Removed direct SSL socket creation and DNS resolution code
    - Maintained identical validation rules and error handling
  - TigValidation1Dot5_2024Test.java:
    - Replaced complex SSL mocking with simple SSLValidator mocking
    - Added 6 new test cases covering edge cases and error conditions
    - Simplified test setup by mocking the validator interface instead of SSL internals
    - Enhanced test coverage for cipher validation failures and mixed protocol scenarios

  Code Movement:
  - SSL context creation logic moved from TigValidation1Dot5_2024 to DefaultSSLValidator
  - DNS resolution logic moved from TigValidation1Dot5_2024 to DefaultSSLValidator
  - Socket connection establishment moved from TigValidation1Dot5_2024 to DefaultSSLValidator
  - TLS 1.2 cipher suite validation moved from TigValidation1Dot5_2024 to DefaultSSLValidator

  Architecture Changes:
  - Introduced dependency injection pattern for SSL validation
  - Separated concerns between validation orchestration and SSL operations
  - Made SSL operations mockable for unit testing
  - Maintained backward compatibility with existing constructor