### PR TITLE
bug/RCT-365-InvalidEndpoints

### DIFF
--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
@@ -218,6 +218,14 @@ public class RDAPHttpQuery implements RDAPQuery {
             String statusValue =
                 httpResponse == null ? "no response available" : String.valueOf(httpResponse.statusCode());
             addErrorToResultsFile(-13002, statusValue, "The HTTP status code was neither 200 nor 404.");
+            
+            // Early termination for client errors (4xx) - these indicate issues with the request itself
+            // and further validation is not meaningful
+            if (httpResponse != null && httpResponse.statusCode() >= 400 && httpResponse.statusCode() < 500) {
+                logger.info("Client error {} detected, stopping validation early", httpResponse.statusCode());
+                isQuerySuccessful = false;
+                return;
+            }
         }
 
         // If it wasn't successful, early return, we don't need to validate

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/tig_section/general/TigValidation1Dot6Test.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/tig_section/general/TigValidation1Dot6Test.java
@@ -5,8 +5,10 @@ import static com.github.tomakehurst.wiremock.client.WireMock.head;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
 
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import java.net.InetAddress;
@@ -15,6 +17,8 @@ import org.icann.rdapconformance.validator.workflow.profile.ProfileValidation;
 import org.icann.rdapconformance.validator.workflow.rdap.HttpTestingUtils;
 import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidatorResults;
 import org.icann.rdapconformance.validator.workflow.rdap.ValidationTest;
+import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidationResult;
+import org.mockito.ArgumentCaptor;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -75,6 +79,59 @@ public class TigValidation1Dot6Test extends HttpTestingUtils implements Validati
       validateNotOk(results, -20300,
           200 + "\n/\n" + 404,
           "The HTTP Status code obtained when using the HEAD method is different from the "
+              + "GET method. See section 1.6 of the RDAP_Technical_Implementation_Guide_2_1.");
+    }
+  }
+
+  @Test
+  public void testValidate_HttpHead400Error_HandledProperly() throws Exception {
+    try (var mockedStatic = mockStatic(DNSCacheResolver.class)) {
+      mockedStatic.when(() -> DNSCacheResolver.getFirstV4Address("127.0.0.1"))
+                  .thenReturn(InetAddress.getByName("127.0.0.1"));
+      mockedStatic.when(() -> DNSCacheResolver.getFirstV6Address("127.0.0.1"))
+                  .thenReturn(null);
+
+      givenUri("http");
+      stubFor(head(urlEqualTo(REQUEST_PATH))
+          .withScheme("http")
+          .willReturn(aResponse()
+              .withHeader("Content-Type", "application/rdap+JSON;encoding=UTF-8")
+              .withStatus(400)));
+
+      // When GET returns 400 and HEAD also returns 400, TigValidation1Dot6 should handle it gracefully
+      // This test verifies that TigValidation1Dot6 doesn't add an error when both GET and HEAD return the same 4xx status
+      TigValidation1Dot6 validation = new TigValidation1Dot6(400, config, results);
+      assertThat(validation.validate()).isTrue();
+    }
+  }
+
+  @Test
+  public void testValidate_GetReturns400HeadReturns200_AddResults20300() throws Exception {
+    try (var mockedStatic = mockStatic(DNSCacheResolver.class)) {
+      mockedStatic.when(() -> DNSCacheResolver.getFirstV4Address("127.0.0.1"))
+                  .thenReturn(InetAddress.getByName("127.0.0.1"));
+      mockedStatic.when(() -> DNSCacheResolver.getFirstV6Address("127.0.0.1"))
+                  .thenReturn(null);
+
+      givenUri("http");
+      stubFor(head(urlEqualTo(REQUEST_PATH))
+          .withScheme("http")
+          .willReturn(aResponse()
+              .withHeader("Content-Type", "application/rdap+JSON;encoding=UTF-8")
+              .withStatus(200)));
+
+      // When GET returns 400 but HEAD returns 200, this indicates a server implementation issue
+      TigValidation1Dot6 validation = new TigValidation1Dot6(400, config, results);
+      assertThat(validation.validate()).isFalse();
+      
+      // Should record the error -20300
+      ArgumentCaptor<RDAPValidationResult> resultCaptor = ArgumentCaptor.forClass(RDAPValidationResult.class);
+      verify(results).add(resultCaptor.capture());
+      RDAPValidationResult result = resultCaptor.getValue();
+      assertThat(result).hasFieldOrPropertyWithValue("code", -20300)
+          .hasFieldOrPropertyWithValue("value", 400 + "\n/\n" + 200)
+          .hasFieldOrPropertyWithValue("message", 
+              "The HTTP Status code obtained when using the HEAD method is different from the "
               + "GET method. See section 1.6 of the RDAP_Technical_Implementation_Guide_2_1.");
     }
   }


### PR DESCRIPTION
## Required Information

### PR Description (Include comprehensive description)
The conformance tool was running through the entire test suite and not exiting correctly with the correct set of errors at the correct time.


#### Summary of changes:

Re-Implement the error handling logic for bad endpoints

#### Problem/feature addressed:

#### Relevant screenshots/diagrams:

#### Links to relevant issues/tasks:
RCT-365

### Branch Name

bug/RCT-365-InvalidEndpoints

- [x] Does the branch name follow the Branch Naming Convention?

#### If not, explain why:

### Code Changes

- [x] Are code changes adhering to coding standards and practices?

#### If not, explain why:

### Commit Messages

- [x] Do commit messages follow [Conventional Commits guidelines](https://wecann.icann.org/docs/DOC-40501)?
- [x] Are they clear, concise, and informative using imperative language?

#### If not, explain why:

### Tests and Test Coverage

- [x] Are changes covered by appropriate tests?
- [x] Were unit tests, integration tests, and end-to-end tests run?
- [x] Was the test coverage maintained or improved? Please include before/after results.

#### If not, explain why:

### Bug Fixes and Tests

- [ ] For bug fixes, are there:
    - [ ] Tests that reproduce the bug before the changes?
    - [x] Tests that demonstrate the bug is resolved after the changes?

#### If not, explain why:

Manual testing

### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Documentation

- [ ] Are there updates to documentation that need to be made?
- [ ] Are they included or linked in the PR description?

#### If not, explain why:

None needed

### PR Size

- [x] Is the PR small and focused on one logical change?

#### If not, explain why:

---