### PR TITLE
feat/RCT-343-AllowRegistrars

### DIFF
--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/tig_section/registry/TigValidation3Dot2Test.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/tig_section/registry/TigValidation3Dot2Test.java
@@ -97,7 +97,7 @@ public class TigValidation3Dot2Test extends ProfileJsonValidationTestBase {
     assertThat(getProfileValidation().doLaunch()).isFalse();
   }
 
-  // RCT-104 only apply if the query is for a gtld registry and the value is not 9999
+  // RCT-104 only apply if the query is for a gtld registry and the value is not in excluded range (9994-9999)
   @Test
   public void testValidate_NoLinksInTopmostObjectWithRegistrar9999_AddResults23200() {
     JSONObject identifier = new JSONObject();
@@ -114,10 +114,10 @@ public class TigValidation3Dot2Test extends ProfileJsonValidationTestBase {
     jsonObject.put("entities", entities);
 
     TigValidation3Dot2 tigValidation3Dot2 = new TigValidation3Dot2(jsonObject.toString(), results, config, queryType);
-    assertThat(tigValidation3Dot2.isRegistrarId9999()).isTrue();
+    assertThat(tigValidation3Dot2.isExcludedRegistrarId()).isTrue();
   }
 
-  // RCT-104 only apply if the query is for a gtld registry and the value is not 9999
+  // RCT-104 only apply if the query is for a gtld registry and the value is not in excluded range (9994-9999)
   @Test
   public void testValidate_NoLinksInTopmostObjectWithRegistrar9998_AddResults23200() {
     JSONObject identifier = new JSONObject();
@@ -134,6 +134,117 @@ public class TigValidation3Dot2Test extends ProfileJsonValidationTestBase {
     jsonObject.put("entities", entities);
 
     TigValidation3Dot2 tigValidation3Dot2 = new TigValidation3Dot2(jsonObject.toString(), results, config, queryType);
-    assertThat(tigValidation3Dot2.isRegistrarId9999()).isFalse();
+    assertThat(tigValidation3Dot2.isExcludedRegistrarId()).isTrue();
+  }
+
+  @Test
+  public void testValidate_ExcludedRegistrar9994_IsExcluded() {
+    JSONObject identifier = new JSONObject();
+    identifier.put("identifier", "9994");
+
+    JSONArray publicIdArray = new JSONArray();
+    publicIdArray.put(identifier);
+
+    JSONObject publicIds = new JSONObject();
+    publicIds.put("publicIds", publicIdArray);
+
+    JSONArray entities = new JSONArray();
+    entities.put(publicIds);
+    jsonObject.put("entities", entities);
+
+    TigValidation3Dot2 tigValidation3Dot2 = new TigValidation3Dot2(jsonObject.toString(), results, config, queryType);
+    assertThat(tigValidation3Dot2.isExcludedRegistrarId()).isTrue();
+  }
+
+  @Test
+  public void testValidate_ExcludedRegistrar9995_IsExcluded() {
+    JSONObject identifier = new JSONObject();
+    identifier.put("identifier", "9995");
+
+    JSONArray publicIdArray = new JSONArray();
+    publicIdArray.put(identifier);
+
+    JSONObject publicIds = new JSONObject();
+    publicIds.put("publicIds", publicIdArray);
+
+    JSONArray entities = new JSONArray();
+    entities.put(publicIds);
+    jsonObject.put("entities", entities);
+
+    TigValidation3Dot2 tigValidation3Dot2 = new TigValidation3Dot2(jsonObject.toString(), results, config, queryType);
+    assertThat(tigValidation3Dot2.isExcludedRegistrarId()).isTrue();
+  }
+
+  @Test
+  public void testValidate_ExcludedRegistrar9996_IsExcluded() {
+    JSONObject identifier = new JSONObject();
+    identifier.put("identifier", "9996");
+
+    JSONArray publicIdArray = new JSONArray();
+    publicIdArray.put(identifier);
+
+    JSONObject publicIds = new JSONObject();
+    publicIds.put("publicIds", publicIdArray);
+
+    JSONArray entities = new JSONArray();
+    entities.put(publicIds);
+    jsonObject.put("entities", entities);
+
+    TigValidation3Dot2 tigValidation3Dot2 = new TigValidation3Dot2(jsonObject.toString(), results, config, queryType);
+    assertThat(tigValidation3Dot2.isExcludedRegistrarId()).isTrue();
+  }
+
+  @Test
+  public void testValidate_ExcludedRegistrar9997_IsExcluded() {
+    JSONObject identifier = new JSONObject();
+    identifier.put("identifier", "9997");
+
+    JSONArray publicIdArray = new JSONArray();
+    publicIdArray.put(identifier);
+
+    JSONObject publicIds = new JSONObject();
+    publicIds.put("publicIds", publicIdArray);
+
+    JSONArray entities = new JSONArray();
+    entities.put(publicIds);
+    jsonObject.put("entities", entities);
+
+    TigValidation3Dot2 tigValidation3Dot2 = new TigValidation3Dot2(jsonObject.toString(), results, config, queryType);
+    assertThat(tigValidation3Dot2.isExcludedRegistrarId()).isTrue();
+  }
+
+  @Test
+  public void testValidate_NonExcludedRegistrar1000_NotExcluded() {
+    JSONObject identifier = new JSONObject();
+    identifier.put("identifier", "1000");
+
+    JSONArray publicIdArray = new JSONArray();
+    publicIdArray.put(identifier);
+
+    JSONObject publicIds = new JSONObject();
+    publicIds.put("publicIds", publicIdArray);
+
+    JSONArray entities = new JSONArray();
+    entities.put(publicIds);
+    jsonObject.put("entities", entities);
+
+    TigValidation3Dot2 tigValidation3Dot2 = new TigValidation3Dot2(jsonObject.toString(), results, config, queryType);
+    assertThat(tigValidation3Dot2.isExcludedRegistrarId()).isFalse();
+  }
+
+  @Test
+  public void testValidate_NoEntities_NotExcluded() {
+    jsonObject.remove("entities");
+
+    TigValidation3Dot2 tigValidation3Dot2 = new TigValidation3Dot2(jsonObject.toString(), results, config, queryType);
+    assertThat(tigValidation3Dot2.isExcludedRegistrarId()).isFalse();
+  }
+
+  @Test
+  public void testValidate_EmptyEntities_NotExcluded() {
+    jsonObject.put("entities", new JSONArray());
+
+    TigValidation3Dot2 tigValidation3Dot2 = new TigValidation3Dot2(jsonObject.toString(), results, config, queryType);
+    assertThat(tigValidation3Dot2.isExcludedRegistrarId()).isFalse();
   }
 }


### PR DESCRIPTION
## Required Information

### PR Description (Include comprehensive description)
Implement IANA reserved registrars for code -23200

#### Summary of changes:
 Implement new Registrars for code -23200
 
#### Problem/feature addressed:
IANA has several Registrar codes that should be exempt - make it so!

#### Relevant screenshots/diagrams:

#### Links to relevant issues/tasks:
https://icann-jira.atlassian.net/browse/RCT-343

### Branch Name
feat/RCT-343-AllowRegistrars

- [x] Does the branch name follow the Branch Naming Convention?

#### If not, explain why:

### Code Changes

- [x] Are code changes adhering to coding standards and practices?

#### If not, explain why:

### Commit Messages

- [x] Do commit messages follow [Conventional Commits guidelines](https://wecann.icann.org/docs/DOC-40501)?
- [x] Are they clear, concise, and informative using imperative language?

#### If not, explain why:

### Tests and Test Coverage

- [x] Are changes covered by appropriate tests?
- [x] Were unit tests, integration tests, and end-to-end tests run?
- [x] Was the test coverage maintained or improved? Please include before/after results.

#### If not, explain why:

### Bug Fixes and Tests

- [ ] For bug fixes, are there:
    - [ ] Tests that reproduce the bug before the changes?
    - [ ] Tests that demonstrate the bug is resolved after the changes?

#### If not, explain why:

### Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Documentation

- [ ] Are there updates to documentation that need to be made?
- [ ] Are they included or linked in the PR description?

#### If not, explain why:
A different team does that.

### PR Size

- [ ] Is the PR small and focused on one logical change?

#### If not, explain why:

---