### PR TITLE
bug/RCT-367-RedactedForPrivacy2

### DIFF
--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/entities/ResponseValidation2Dot7Dot1DotXAndRelated2.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/entities/ResponseValidation2Dot7Dot1DotXAndRelated2.java
@@ -7,6 +7,7 @@ import org.icann.rdapconformance.validator.jcard.JcardCategoriesSchemas;
 import org.icann.rdapconformance.validator.workflow.rdap.RDAPQueryType;
 import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidationResult;
 import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidatorResults;
+import org.json.JSONArray;
 import org.json.JSONObject;
 
 /**
@@ -14,6 +15,32 @@ import org.json.JSONObject;
  */
 public class ResponseValidation2Dot7Dot1DotXAndRelated2 extends
     ResponseValidation2Dot7Dot1DotXAndRelated {
+
+  // vCard adr property array indices per RFC 6350 Section 6.3.1
+  private static final int ADR_STREET_INDEX = 2;
+  private static final int ADR_CITY_INDEX = 3;
+  
+  // vCard property structure - value is at index 3 per RFC 6350
+  private static final int VCARD_VALUE_INDEX = 3;
+  private static final int VCARD_ADR_VALUE_ARRAY_INDEX = 3; // adr property value is at index 3
+  
+  // Entity field names
+  private static final String HANDLE_FIELD = "handle";
+  
+  // vCard property names per RFC 6350
+  private static final String VCARD_PROPERTY_FN = "fn";
+  private static final String VCARD_PROPERTY_ADR = "adr";  
+  private static final String VCARD_PROPERTY_TEL = "tel";
+  
+  // JSONPath expressions
+  private static final String REDACTED_FOR_PRIVACY_REMARKS_PATH = "$.remarks[?(@.title == 'REDACTED FOR PRIVACY')]";
+  private static final String VCARD_ARRAY_PATH_TEMPLATE = "vcardArray[1][?(@[0] == '%s')]";
+  private static final String VCARD_ADR_PROPERTIES_PATH = "vcardArray[1][?(@[0]=='adr')]";
+  
+  // Error code and message
+  private static final int ERROR_CODE_52101 = -52101;
+  private static final String ERROR_MESSAGE_52101 = "An entity without a remark titled \"REDACTED FOR PRIVACY\" " +
+          "does not have all the necessary information of handle, fn, adr, tel, street and city.";
 
   public ResponseValidation2Dot7Dot1DotXAndRelated2(String rdapResponse,
       RDAPValidatorResults results,
@@ -29,17 +56,28 @@ public class ResponseValidation2Dot7Dot1DotXAndRelated2 extends
     }
 
     Set<String> withRemarkTitleRedactedForPrivacy =
-        getPointerFromJPath(entity, "$.remarks[?(@.title == 'REDACTED FOR PRIVACY')]");
+        getPointerFromJPath(entity, REDACTED_FOR_PRIVACY_REMARKS_PATH);
 
     boolean isValid = true;
     if (withRemarkTitleRedactedForPrivacy.isEmpty()) {
       // Validate handle field (top-level entity property)
-      if (!entity.has("handle")) {
+      if (!entity.has(HANDLE_FIELD)) {
         isValid &= log52101(jsonPointer);
+      } else {
+        // Check handle content is not empty
+        try {
+          String handleValue = entity.getString(HANDLE_FIELD);
+          if (handleValue.trim().isEmpty()) {
+            isValid &= log52101(jsonPointer);
+          }
+        } catch (Exception e) {
+          // Handle is not a string or malformed
+          isValid &= log52101(jsonPointer);
+        }
       }
       
-      // Validate vcard properties
-      Set<String> properties = Set.of("fn", "adr", "tel", "email");
+      // Validate vcard properties per story requirements
+      Set<String> properties = Set.of(VCARD_PROPERTY_FN, VCARD_PROPERTY_ADR, VCARD_PROPERTY_TEL);
       for (String property : properties) {
         isValid &= validateVcardProperty(jsonPointer, entity, property);
       }
@@ -62,13 +100,78 @@ public class ResponseValidation2Dot7Dot1DotXAndRelated2 extends
           isValid &= log52101(jsonPointer);
         }
 
-        if (property.equals("adr")) {
-          // check if adr contains an address with street (index == 2), City (index == 3) & Country (index == 6)
-          Set<String> adrPointers = getPointerFromJPath(entity,
-              "vcardArray[1][?(@[0]=='adr')][3][2,3]");
-          if (adrPointers.size() < 2) {
-            // less than 3 means an address component is missing, we log an error:
+        // Check for empty content in key vCard properties per story requirements
+        if (property.equals(VCARD_PROPERTY_FN) || property.equals(VCARD_PROPERTY_TEL)) {
+          try {
+            JSONArray vcardProperty = (JSONArray) entity.query(propertyPointer);
+            Object valueObj = vcardProperty.get(VCARD_VALUE_INDEX);
+            if (valueObj instanceof String value) {
+              if (value.trim().isEmpty()) {
+                isValid &= log52101(jsonPointer);
+                continue; // Skip to next property pointer
+              }
+            } else {
+              // Value is not a string (invalid format)
+              isValid &= log52101(jsonPointer);
+              continue;
+            }
+          } catch (Exception e) {
+            // Malformed vCard property
             isValid &= log52101(jsonPointer);
+            continue;
+          }
+        }
+
+        if (property.equals(VCARD_PROPERTY_ADR)) {
+          // Check if adr contains meaningful street (index 2) and city (index 3) values
+          Set<String> adrPropertyPointers = getPointerFromJPath(entity, VCARD_ADR_PROPERTIES_PATH);
+          for (String adrPropertyPointer : adrPropertyPointers) {
+            try {
+              JSONArray adrProperty = (JSONArray) entity.query(adrPropertyPointer);
+              JSONArray adrValues = adrProperty.getJSONArray(VCARD_ADR_VALUE_ARRAY_INDEX);
+              
+              // Check street (index 2) - must be non-empty string
+              if (adrValues.length() > ADR_STREET_INDEX) {
+                Object streetObj = adrValues.get(ADR_STREET_INDEX);
+                if (streetObj instanceof String street) {
+                  if (street.trim().isEmpty()) {
+                    isValid &= log52101(jsonPointer);
+                    break;
+                  }
+                } else {
+                  // Street is not a string (invalid format)
+                  isValid &= log52101(jsonPointer);
+                  break;
+                }
+              } else {
+                // Street index missing
+                isValid &= log52101(jsonPointer);
+                break;
+              }
+              
+              // Check city (index 3) - must be non-empty string
+              if (adrValues.length() > ADR_CITY_INDEX) {
+                Object cityObj = adrValues.get(ADR_CITY_INDEX);
+                if (cityObj instanceof String city) {
+                  if (city.trim().isEmpty()) {
+                    isValid &= log52101(jsonPointer);
+                    break;
+                  }
+                } else {
+                  // City is not a string (invalid format)
+                  isValid &= log52101(jsonPointer);
+                  break;
+                }
+              } else {
+                // City index missing
+                isValid &= log52101(jsonPointer);
+                break;
+              }
+            } catch (Exception e) {
+              // Malformed adr property
+              isValid &= log52101(jsonPointer);
+              break;
+            }
           }
         }
       }
@@ -77,15 +180,14 @@ public class ResponseValidation2Dot7Dot1DotXAndRelated2 extends
   }
 
   private Set<String> getVcardPropertyPointers(JSONObject entity, String property) {
-    return getPointerFromJPath(entity, "vcardArray[1][?(@[0] == '" + property + "')]");
+    return getPointerFromJPath(entity, String.format(VCARD_ARRAY_PATH_TEMPLATE, property));
   }
 
   private boolean log52101(String jsonPointer) {
     results.add(RDAPValidationResult.builder()
-        .code(-52101)
+        .code(ERROR_CODE_52101)
         .value(getResultValue(jsonPointer))
-        .message("An entity without a remark titled \"REDACTED FOR PRIVACY\" " +
-                "does not have all the necessary information of handle, fn, adr, tel, street and city.")
+        .message(ERROR_MESSAGE_52101)
         .build());
     return false;
   }

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/ProfileValidationTestBase.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/ProfileValidationTestBase.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import org.icann.rdapconformance.validator.configuration.RDAPValidatorConfiguration;
 import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidatorResults;
 import org.icann.rdapconformance.validator.workflow.rdap.ValidationTest;
+import org.icann.rdapconformance.validator.workflow.rdap.http.RDAPHttpRequest;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -31,6 +32,10 @@ public abstract class ProfileValidationTestBase implements ValidationTest {
     results = mock(RDAPValidatorResults.class);
     config = mock(RDAPValidatorConfiguration.class);
     when(config.isGtldRegistrar()).thenReturn(true);
+    
+    // PERFORMANCE FIX: Reduce HTTP 429 retry backoff from 30 seconds to 1 second for tests
+    // This prevents tests from hanging for 30 seconds when hitting rate limits
+    RDAPHttpRequest.DEFAULT_BACKOFF_SECS = 1;
   }
 
   @Test

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/entities/ResponseValidation2Dot7Dot1DotXAndRelated2Test.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/domain/entities/ResponseValidation2Dot7Dot1DotXAndRelated2Test.java
@@ -46,16 +46,142 @@ public class ResponseValidation2Dot7Dot1DotXAndRelated2Test extends
     validateWithoutProperty("tel");
   }
 
-  @Test
-  public void withoutEmailWithoutRedactedForPrivacyTitle() {
-    validateWithoutProperty("email");
-  }
 
   @Test
   public void countryNotIncludedInAdrProperty() {
     // remove all elements including country:
     removeKey("$.['entities'][0]['vcardArray'][1][4][3][2:6]");
     assertThat((List<String>) getValue("$.['entities'][0]['vcardArray'][1][4][3]")).hasSize(3);
+    validate52101();
+  }
+
+  @Test
+  public void emptyStreetInAdrProperty() {
+    // Set street (index 2) to empty string
+    replaceValue("$.['entities'][0]['vcardArray'][1][4][3][2]", "");
+    validate52101();
+  }
+
+  @Test
+  public void emptyCityInAdrProperty() {
+    // Set city (index 3) to empty string
+    replaceValue("$.['entities'][0]['vcardArray'][1][4][3][3]", "");
+    validate52101();
+  }
+
+  @Test
+  public void emptyStreetAndCityInAdrProperty() {
+    // Set both street (index 2) and city (index 3) to empty strings
+    replaceValue("$.['entities'][0]['vcardArray'][1][4][3][2]", "");
+    replaceValue("$.['entities'][0]['vcardArray'][1][4][3][3]", "");
+    validate52101();
+  }
+
+  @Test
+  public void whitespaceOnlyStreetInAdrProperty() {
+    // Set street (index 2) to whitespace-only string
+    replaceValue("$.['entities'][0]['vcardArray'][1][4][3][2]", "   ");
+    validate52101();
+  }
+
+  @Test
+  public void whitespaceOnlyCityInAdrProperty() {
+    // Set city (index 3) to whitespace-only string
+    replaceValue("$.['entities'][0]['vcardArray'][1][4][3][3]", "   ");
+    validate52101();
+  }
+
+  // Removed: nonStringStreetInAdrProperty and nonStringCityInAdrProperty 
+  // Coverage provided by truncatedAdrArrayMissing* tests
+
+  @Test
+  public void truncatedAdrArrayMissingStreet() {
+    // Truncate address array to only have 2 elements (missing street at index 2)
+    replaceValue("$.['entities'][0]['vcardArray'][1][4][3]", List.of("", ""));
+    validate52101();
+  }
+
+  @Test
+  public void truncatedAdrArrayMissingCity() {
+    // Truncate address array to only have 3 elements (missing city at index 3)  
+    replaceValue("$.['entities'][0]['vcardArray'][1][4][3]", List.of("", "", "123 Main St"));
+    validate52101();
+  }
+
+  @Test
+  public void entityWithRedactedForPrivacyRemark() {
+    // Test the other branch - entity WITH "REDACTED FOR PRIVACY" remark should not trigger validation
+    entitiesWithRole("registrant");
+    remarkMemberIs("title", "REDACTED FOR PRIVACY"); // This creates the remarks structure properly
+    
+    // Even with missing properties, should not trigger -52101 when redacted
+    removeKey("$.['entities'][0]['vcardArray'][1][*][?(@ == 'fn')]");
+    removeKey("$.['entities'][0]['vcardArray'][1][*][?(@ == 'email')]");
+    removeKey("$.['entities'][0]['handle']");
+    
+    validate(); // Should pass without -52101 error
+  }
+
+  @Test
+  public void childOfRegistrarEntity() {
+    // Create an entity that is a child of registrar to test isChildOfRegistrar branch
+    replaceValue("$.['entities'][0]['roles']", List.of("registrar"));
+    
+    // Even without required fields, should not trigger -52101 for registrar entities
+    removeKey("$.['entities'][0]['vcardArray'][1][*][?(@ == 'fn')]");
+    removeKey("$.['entities'][0]['handle']");
+    
+    entitiesWithRole("registrar");
+    validate(); // Should pass without -52101 error since it's a registrar
+  }
+
+  @Test
+  public void emptyFnValueInVcard() {
+    // Set fn value (index 3) to empty string
+    replaceValue("$.['entities'][0]['vcardArray'][1][1][3]", "");
+    validate52101();
+  }
+
+  @Test
+  public void whitespaceOnlyFnValueInVcard() {
+    // Set fn value (index 3) to whitespace-only string
+    replaceValue("$.['entities'][0]['vcardArray'][1][1][3]", "   ");
+    validate52101();
+  }
+
+  @Test
+  public void emptyHandleValue() {
+    // Set handle to empty string
+    replaceValue("$.['entities'][0]['handle']", "");
+    validate52101();
+  }
+
+  @Test
+  public void whitespaceOnlyHandleValue() {
+    // Set handle to whitespace-only string
+    replaceValue("$.['entities'][0]['handle']", "   ");
+    validate52101();
+  }
+
+  @Test
+  public void nonStringHandleValue() {
+    // Set handle to non-string value
+    replaceValue("$.['entities'][0]['handle']", 12345);
+    validate52101();
+  }
+
+  @Test
+  public void malformedVcardPropertyTriggersException() {
+    // IMPORTANT: Tests ValidationException catch block for coverage
+    // Create a malformed fn property that will trigger ValidationException
+    replaceValue("$.['entities'][0]['vcardArray'][1][1]", List.of("fn")); // Missing required elements
+    validate52101();
+  }
+
+  @Test 
+  public void malformedAdrArrayStructure() {
+    // IMPORTANT: Tests Exception catch block in adr validation for coverage
+    replaceValue("$.['entities'][0]['vcardArray'][1][4]", List.of("adr", new Object())); // Missing array at index 3  
     validate52101();
   }
 


### PR DESCRIPTION
## Required Information

### PR Description (Include comprehensive description)
Test Case -52101 fails because no error code is triggered when an entity with roles registrant, administrative, technical, or billing

#### Summary of changes:
 Implement the logic for catching when the fields are "" and a fix for the test for 429 timeout
 
#### Problem/feature addressed:
incorrect logic hole

#### Relevant screenshots/diagrams:

#### Links to relevant issues/tasks:
https://icann-jira.atlassian.net/browse/RCT-367

### Branch Name
bug/RCT-367-RedactedForPrivacy2

- [x] Does the branch name follow the Branch Naming Convention?

#### If not, explain why:

### Code Changes

- [x] Are code changes adhering to coding standards and practices?

#### If not, explain why:

### Commit Messages

- [x] Do commit messages follow [Conventional Commits guidelines](https://wecann.icann.org/docs/DOC-40501)?
- [x] Are they clear, concise, and informative using imperative language?

#### If not, explain why:

### Tests and Test Coverage

- [x] Are changes covered by appropriate tests?
- [x] Were unit tests, integration tests, and end-to-end tests run?
- [x] Was the test coverage maintained or improved? Please include before/after results.

#### If not, explain why:

### Bug Fixes and Tests

- [x] For bug fixes, are there:
    - [x] Tests that reproduce the bug before the changes?
    - [x] Tests that demonstrate the bug is resolved after the changes?

#### If not, explain why:

### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Documentation

- [ ] Are there updates to documentation that need to be made?
- [ ] Are they included or linked in the PR description?

#### If not, explain why:
Different team

### PR Size

- [ ] Is the PR small and focused on one logical change?

#### If not, explain why:
```
I fixed a test related to the 429 wait and it was sleeping the default 30seconds and was driving me bonkers.
I knocked this down to ONE second. 
```
---