### PR TITLE
feat/RCT-396-ChangeDNSResolver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <icu4j.version>69.1</icu4j.version>
         <json-path.version>2.9.0</json-path.version>
         <json-smart.version>2.5.2</json-smart.version>
-        <dnsjava.version>3.6.2</dnsjava.version>
+        <dnsjava.version>3.6.3</dnsjava.version>
         <commons-text.version>1.10.0</commons-text.version>
         <testng.version>7.9.0</testng.version>
         <assertj-core.version>3.19.0</assertj-core.version>

--- a/tool/src/test/java/org/icann/rdapconformance/tool/RdapConformanceToolDnsResolverTest.java
+++ b/tool/src/test/java/org/icann/rdapconformance/tool/RdapConformanceToolDnsResolverTest.java
@@ -1,0 +1,105 @@
+package org.icann.rdapconformance.tool;
+
+import org.icann.rdapconformance.validator.ToolResult;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import picocli.CommandLine;
+
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RdapConformanceToolDnsResolverTest {
+
+    private RdapConformanceTool tool;
+
+    @BeforeMethod
+    public void setUp() {
+        tool = new RdapConformanceTool();
+    }
+
+    @Test
+    public void testSetCustomDnsResolver() {
+        tool.setCustomDnsResolver("8.8.8.8");
+        assertThat(tool.getCustomDnsResolver()).isEqualTo("8.8.8.8");
+    }
+
+    @Test
+    public void testGetCustomDnsResolver_DefaultNull() {
+        assertThat(tool.getCustomDnsResolver()).isNull();
+    }
+
+    @Test
+    public void testIsValidIpAddress_ValidIPv4() throws Exception {
+        // Use reflection to access the private method for testing
+        java.lang.reflect.Method method = RdapConformanceTool.class.getDeclaredMethod("isValidIpAddress", String.class);
+        method.setAccessible(true);
+        
+        boolean result = (boolean) method.invoke(tool, "8.8.8.8");
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    public void testIsValidIpAddress_ValidIPv6() throws Exception {
+        // Use reflection to access the private method for testing
+        java.lang.reflect.Method method = RdapConformanceTool.class.getDeclaredMethod("isValidIpAddress", String.class);
+        method.setAccessible(true);
+        
+        boolean result = (boolean) method.invoke(tool, "2001:4860:4860::8888");
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    public void testIsValidIpAddress_InvalidFormat() throws Exception {
+        // Use reflection to access the private method for testing
+        java.lang.reflect.Method method = RdapConformanceTool.class.getDeclaredMethod("isValidIpAddress", String.class);
+        method.setAccessible(true);
+        
+        boolean result = (boolean) method.invoke(tool, "invalid.dns.server");
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    public void testIsValidIpAddress_InvalidIPv4() throws Exception {
+        // Use reflection to access the private method for testing
+        java.lang.reflect.Method method = RdapConformanceTool.class.getDeclaredMethod("isValidIpAddress", String.class);
+        method.setAccessible(true);
+        
+        boolean result = (boolean) method.invoke(tool, "300.300.300.300");
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    public void testCommandLineParsing_WithDnsResolver() {
+        CommandLine cmd = new CommandLine(tool);
+        String[] args = {"--dns-resolver", "8.8.8.8", "-c", "config.json", "--gtld-registry", "--use-rdap-profile-february-2024", "https://example.com"};
+        
+        cmd.parseArgs(args);
+        
+        assertThat(tool.getCustomDnsResolver()).isEqualTo("8.8.8.8");
+    }
+
+    @Test
+    public void testCommandLineParsing_WithoutDnsResolver() {
+        CommandLine cmd = new CommandLine(tool);
+        String[] args = {"-c", "config.json", "--gtld-registry", "--use-rdap-profile-february-2024", "https://example.com"};
+        
+        cmd.parseArgs(args);
+        
+        assertThat(tool.getCustomDnsResolver()).isNull();
+    }
+
+    @Test
+    public void testCall_WithInvalidDnsResolver_ReturnsBadUserInput() throws Exception {
+        // Setup tool with minimal required parameters
+        tool.setCustomDnsResolver("invalid.dns.server");
+        tool.setConfigurationFile("config.json");
+        tool.uri = URI.create("https://example.com");
+        tool.setUseRdapProfileFeb2024(true);
+        tool.setGtldRegistry(true);
+        
+        Integer result = tool.call();
+        
+        assertThat(result).isEqualTo(ToolResult.BAD_USER_INPUT.getCode());
+    }
+}

--- a/validator/src/main/java/org/icann/rdapconformance/validator/NetworkInfo.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/NetworkInfo.java
@@ -1,9 +1,18 @@
 package org.icann.rdapconformance.validator;
 
 import static org.icann.rdapconformance.validator.CommonUtils.DASH;
+import org.icann.rdapconformance.validator.workflow.profile.IPVersionContext;
 
 public class NetworkInfo {
     private static final NetworkInfo instance = new NetworkInfo();
+    
+    // Thread-local storage for parallel execution
+    private static final ThreadLocal<NetworkInfo> threadLocalInstance = 
+        ThreadLocal.withInitial(NetworkInfo::new);
+    
+    // Feature flag to enable thread-local mode
+    private static final boolean USE_THREAD_LOCAL = 
+        "true".equals(System.getProperty("rdap.parallel.ipversions", "false"));
 
     private AcceptHeader acceptHeader = AcceptHeader.APPLICATION_JSON;
     private String httpMethod;
@@ -13,6 +22,12 @@ public class NetworkInfo {
     private NetworkInfo() {}
 
     public static NetworkInfo getInstance() {
+        if (USE_THREAD_LOCAL) {
+            IPVersionContext context = IPVersionContext.current();
+            if (context != null) {
+                return threadLocalInstance.get();
+            }
+        }
         return instance;
     }
 
@@ -34,59 +49,70 @@ public class NetworkInfo {
 
     // Static Getters
     public static String getAcceptHeader() {
-        return instance.acceptHeader.getValue();
+        return getInstance().acceptHeader.getValue();
     }
 
     public static String getHttpMethod() {
-        return (instance.httpMethod == null || instance.httpMethod.isEmpty()) ? DASH : instance.httpMethod;
+        NetworkInfo info = getInstance();
+        return (info.httpMethod == null || info.httpMethod.isEmpty()) ? DASH : info.httpMethod;
     }
 
     public static String getServerIpAddress() {
-        return (instance.serverIpAddress == null || instance.serverIpAddress.isEmpty()) ? DASH : instance.serverIpAddress;
+        NetworkInfo info = getInstance();
+        return (info.serverIpAddress == null || info.serverIpAddress.isEmpty()) ? DASH : info.serverIpAddress;
     }
 
     public static NetworkProtocol getNetworkProtocol() {
-        return instance.networkProtocol;
+        return getInstance().networkProtocol;
     }
 
     public static String getNetworkProtocolAsString() {
-        return (instance.networkProtocol == null) ? DASH : instance.networkProtocol.name();
+        NetworkInfo info = getInstance();
+        return (info.networkProtocol == null) ? DASH : info.networkProtocol.name();
     }
 
     // Static Setters
     public static void setAcceptHeaderToApplicationJson() {
-        instance.acceptHeader = AcceptHeader.APPLICATION_JSON;
+        getInstance().acceptHeader = AcceptHeader.APPLICATION_JSON;
     }
 
     public static void setAcceptHeaderToApplicationRdapJson() {
-        instance.acceptHeader = AcceptHeader.APPLICATION_RDAP_JSON;
+        getInstance().acceptHeader = AcceptHeader.APPLICATION_RDAP_JSON;
     }
 
     public static void setHttpMethod(String httpMethod) {
-        instance.httpMethod = httpMethod;
+        getInstance().httpMethod = httpMethod;
     }
 
     public static void setServerIpAddress(String serverIpAddress) {
-        instance.serverIpAddress = serverIpAddress;
+        getInstance().serverIpAddress = serverIpAddress;
     }
 
     public static void setNetworkProtocol(NetworkProtocol protocol) {
-        instance.networkProtocol = protocol;
+        getInstance().networkProtocol = protocol;
     }
 
     public static void setStackToV6() {
         setNetworkProtocol(NetworkProtocol.IPv6);
-        System.setProperty("java.net.preferIPv4Addresses", "false");
-        System.setProperty("java.net.preferIPv4Stack", "false");
-        System.setProperty("java.net.preferIPv6Addresses", "true");
-        System.setProperty("java.net.preferIPv6Stack", "true");
+        // Only set system properties in non-thread-local mode
+        // In thread-local mode, IPVersionContext handles system properties
+        if (!USE_THREAD_LOCAL || IPVersionContext.current() == null) {
+            System.setProperty("java.net.preferIPv4Addresses", "false");
+            System.setProperty("java.net.preferIPv4Stack", "false");
+            System.setProperty("java.net.preferIPv6Addresses", "true");
+            System.setProperty("java.net.preferIPv6Stack", "true");
+        }
     }
 
     public static void setStackToV4() {
         setNetworkProtocol(NetworkProtocol.IPv4);
-        System.setProperty("java.net.preferIPv6Addresses", "false");
-        System.setProperty("java.net.preferIPv6Stack", "false");
-        System.setProperty("java.net.preferIPv4Addresses", "true");
-        System.setProperty("java.net.preferIPv4Stack", "true");
+        // Only set system properties in non-thread-local mode
+        // In thread-local mode, IPVersionContext handles system properties
+        if (!USE_THREAD_LOCAL || IPVersionContext.current() == null) {
+            System.setProperty("java.net.preferIPv6Addresses", "false");
+            System.setProperty("java.net.preferIPv6Stack", "false");
+            System.setProperty("java.net.preferIPv4Addresses", "true");
+            System.setProperty("java.net.preferIPv4Stack", "true");
+        }
     }
 }

--- a/validator/src/main/java/org/icann/rdapconformance/validator/NetworkInfo.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/NetworkInfo.java
@@ -94,25 +94,9 @@ public class NetworkInfo {
 
     public static void setStackToV6() {
         setNetworkProtocol(NetworkProtocol.IPv6);
-        // Only set system properties in non-thread-local mode
-        // In thread-local mode, IPVersionContext handles system properties
-        if (!USE_THREAD_LOCAL || IPVersionContext.current() == null) {
-            System.setProperty("java.net.preferIPv4Addresses", "false");
-            System.setProperty("java.net.preferIPv4Stack", "false");
-            System.setProperty("java.net.preferIPv6Addresses", "true");
-            System.setProperty("java.net.preferIPv6Stack", "true");
-        }
     }
 
     public static void setStackToV4() {
         setNetworkProtocol(NetworkProtocol.IPv4);
-        // Only set system properties in non-thread-local mode
-        // In thread-local mode, IPVersionContext handles system properties
-        if (!USE_THREAD_LOCAL || IPVersionContext.current() == null) {
-            System.setProperty("java.net.preferIPv6Addresses", "false");
-            System.setProperty("java.net.preferIPv6Stack", "false");
-            System.setProperty("java.net.preferIPv4Addresses", "true");
-            System.setProperty("java.net.preferIPv4Stack", "true");
-        }
     }
 }

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/IPVersionContext.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/IPVersionContext.java
@@ -4,25 +4,16 @@ import org.icann.rdapconformance.validator.NetworkProtocol;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Context object for isolated IP version execution.
- * Manages thread-local System properties to enable parallel IPv4/IPv6 execution.
+ * Provides thread-local IP version context to enable parallel IPv4/IPv6 execution.
  */
 public class IPVersionContext {
     private static final Logger logger = LoggerFactory.getLogger(IPVersionContext.class);
     
     private final NetworkProtocol protocol;
-    private final Map<String, String> originalSystemProps = new HashMap<>();
     private static final ThreadLocal<IPVersionContext> currentContext = new ThreadLocal<>();
-    
-    // System properties that control IP version preferences
-    private static final String PREFER_IPV6_ADDRESSES = "java.net.preferIPv6Addresses";
-    private static final String PREFER_IPV6_STACK = "java.net.preferIPv6Stack";
-    private static final String PREFER_IPV4_ADDRESSES = "java.net.preferIPv4Addresses";
-    private static final String PREFER_IPV4_STACK = "java.net.preferIPv4Stack";
     
     public IPVersionContext(NetworkProtocol protocol) {
         this.protocol = protocol;
@@ -30,41 +21,18 @@ public class IPVersionContext {
     
     /**
      * Activates this context for the current thread.
-     * Sets System properties to prefer the configured IP version.
      */
     public void activate() {
         logger.debug("Activating IPVersionContext for {}", protocol);
         currentContext.set(this);
-        
-        // Save original system properties
-        saveSystemProperties();
-        
-        // Set properties for this IP version
-        if (protocol == NetworkProtocol.IPv6) {
-            System.setProperty(PREFER_IPV6_ADDRESSES, "true");
-            System.setProperty(PREFER_IPV6_STACK, "true");
-            System.setProperty(PREFER_IPV4_ADDRESSES, "false");
-            System.setProperty(PREFER_IPV4_STACK, "false");
-            logger.debug("Set System properties to prefer IPv6");
-        } else {
-            System.setProperty(PREFER_IPV4_ADDRESSES, "true");
-            System.setProperty(PREFER_IPV4_STACK, "true");
-            System.setProperty(PREFER_IPV6_ADDRESSES, "false");
-            System.setProperty(PREFER_IPV6_STACK, "false");
-            logger.debug("Set System properties to prefer IPv4");
-        }
     }
     
     /**
-     * Deactivates this context, restoring original System properties.
+     * Deactivates this context.
      */
     public void deactivate() {
         logger.debug("Deactivating IPVersionContext for {}", protocol);
-        try {
-            restoreSystemProperties();
-        } finally {
-            currentContext.remove();
-        }
+        currentContext.remove();
     }
     
     /**
@@ -89,35 +57,16 @@ public class IPVersionContext {
         return currentContext.get() == this;
     }
     
-    /**
-     * Saves current System properties so they can be restored later.
+    /*
+     * NOTE: We previously manipulated java.net.preferIPv4Addresses
+     * and java.net.preferIPv6Addresses here, but they have absolutely no effect when
+     * changed at runtime. The JVM networking stack  reads these once at startup and that's it.
+     * Instead, we switch the IP version through explicit the local address
+     * binding in LocalBindRoutePlanner.
+     * 
+     * If Oracle/OpenJDK ever implements runtime-effective IP preference system properties,
+     * we could just flip the vars back and forth.
      */
-    private void saveSystemProperties() {
-        originalSystemProps.put(PREFER_IPV6_ADDRESSES, 
-            System.getProperty(PREFER_IPV6_ADDRESSES, "false"));
-        originalSystemProps.put(PREFER_IPV6_STACK, 
-            System.getProperty(PREFER_IPV6_STACK, "false"));
-        originalSystemProps.put(PREFER_IPV4_ADDRESSES, 
-            System.getProperty(PREFER_IPV4_ADDRESSES, "true"));
-        originalSystemProps.put(PREFER_IPV4_STACK, 
-            System.getProperty(PREFER_IPV4_STACK, "false"));
-        
-        logger.debug("Saved original System properties: {}", originalSystemProps);
-    }
-    
-    /**
-     * Restores System properties to their original values.
-     */
-    private void restoreSystemProperties() {
-        originalSystemProps.forEach((key, value) -> {
-            if (value != null) {
-                System.setProperty(key, value);
-            } else {
-                System.clearProperty(key);
-            }
-        });
-        logger.debug("Restored System properties to original values");
-    }
     
     @Override
     public String toString() {

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/IPVersionContext.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/IPVersionContext.java
@@ -1,0 +1,126 @@
+package org.icann.rdapconformance.validator.workflow.profile;
+
+import org.icann.rdapconformance.validator.NetworkProtocol;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Context object for isolated IP version execution.
+ * Manages thread-local System properties to enable parallel IPv4/IPv6 execution.
+ */
+public class IPVersionContext {
+    private static final Logger logger = LoggerFactory.getLogger(IPVersionContext.class);
+    
+    private final NetworkProtocol protocol;
+    private final Map<String, String> originalSystemProps = new HashMap<>();
+    private static final ThreadLocal<IPVersionContext> currentContext = new ThreadLocal<>();
+    
+    // System properties that control IP version preferences
+    private static final String PREFER_IPV6_ADDRESSES = "java.net.preferIPv6Addresses";
+    private static final String PREFER_IPV6_STACK = "java.net.preferIPv6Stack";
+    private static final String PREFER_IPV4_ADDRESSES = "java.net.preferIPv4Addresses";
+    private static final String PREFER_IPV4_STACK = "java.net.preferIPv4Stack";
+    
+    public IPVersionContext(NetworkProtocol protocol) {
+        this.protocol = protocol;
+    }
+    
+    /**
+     * Activates this context for the current thread.
+     * Sets System properties to prefer the configured IP version.
+     */
+    public void activate() {
+        logger.debug("Activating IPVersionContext for {}", protocol);
+        currentContext.set(this);
+        
+        // Save original system properties
+        saveSystemProperties();
+        
+        // Set properties for this IP version
+        if (protocol == NetworkProtocol.IPv6) {
+            System.setProperty(PREFER_IPV6_ADDRESSES, "true");
+            System.setProperty(PREFER_IPV6_STACK, "true");
+            System.setProperty(PREFER_IPV4_ADDRESSES, "false");
+            System.setProperty(PREFER_IPV4_STACK, "false");
+            logger.debug("Set System properties to prefer IPv6");
+        } else {
+            System.setProperty(PREFER_IPV4_ADDRESSES, "true");
+            System.setProperty(PREFER_IPV4_STACK, "true");
+            System.setProperty(PREFER_IPV6_ADDRESSES, "false");
+            System.setProperty(PREFER_IPV6_STACK, "false");
+            logger.debug("Set System properties to prefer IPv4");
+        }
+    }
+    
+    /**
+     * Deactivates this context, restoring original System properties.
+     */
+    public void deactivate() {
+        logger.debug("Deactivating IPVersionContext for {}", protocol);
+        try {
+            restoreSystemProperties();
+        } finally {
+            currentContext.remove();
+        }
+    }
+    
+    /**
+     * Gets the current IPVersionContext for this thread.
+     * @return the current context, or null if none is active
+     */
+    public static IPVersionContext current() {
+        return currentContext.get();
+    }
+    
+    /**
+     * Gets the network protocol for this context.
+     */
+    public NetworkProtocol getProtocol() {
+        return protocol;
+    }
+    
+    /**
+     * Checks if this context is currently active for this thread.
+     */
+    public boolean isActive() {
+        return currentContext.get() == this;
+    }
+    
+    /**
+     * Saves current System properties so they can be restored later.
+     */
+    private void saveSystemProperties() {
+        originalSystemProps.put(PREFER_IPV6_ADDRESSES, 
+            System.getProperty(PREFER_IPV6_ADDRESSES, "false"));
+        originalSystemProps.put(PREFER_IPV6_STACK, 
+            System.getProperty(PREFER_IPV6_STACK, "false"));
+        originalSystemProps.put(PREFER_IPV4_ADDRESSES, 
+            System.getProperty(PREFER_IPV4_ADDRESSES, "true"));
+        originalSystemProps.put(PREFER_IPV4_STACK, 
+            System.getProperty(PREFER_IPV4_STACK, "false"));
+        
+        logger.debug("Saved original System properties: {}", originalSystemProps);
+    }
+    
+    /**
+     * Restores System properties to their original values.
+     */
+    private void restoreSystemProperties() {
+        originalSystemProps.forEach((key, value) -> {
+            if (value != null) {
+                System.setProperty(key, value);
+            } else {
+                System.clearProperty(key);
+            }
+        });
+        logger.debug("Restored System properties to original values");
+    }
+    
+    @Override
+    public String toString() {
+        return "IPVersionContext{protocol=" + protocol + ", active=" + isActive() + "}";
+    }
+}

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/NetworkValidationCoordinator.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/NetworkValidationCoordinator.java
@@ -9,6 +9,15 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
+import java.util.HashMap;
+import java.util.Map;
+import org.icann.rdapconformance.validator.workflow.ValidatorWorkflow;
+import org.icann.rdapconformance.validator.DNSCacheResolver;
+import org.icann.rdapconformance.validator.NetworkInfo;
+import org.icann.rdapconformance.validator.NetworkProtocol;
+import java.net.URI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,6 +35,10 @@ public class NetworkValidationCoordinator {
     // Opt-in mechanism - user must explicitly enable parallel networking
     private static final boolean PARALLEL_NETWORK_ENABLED = 
         "true".equals(System.getProperty("rdap.parallel.network", "false"));
+        
+    // Feature flag for IP version parallelization
+    private static final boolean PARALLEL_IP_VERSIONS_ENABLED = 
+        "true".equals(System.getProperty("rdap.parallel.ipversions", "false"));
     
     // Thread pool for network validations
     private static final ExecutorService networkExecutor = 
@@ -44,6 +57,14 @@ public class NetworkValidationCoordinator {
                 t.setDaemon(true);
                 return t;
             });
+            
+    // Thread pool specifically for IP version parallelization
+    private static final ExecutorService ipVersionExecutor = 
+        Executors.newFixedThreadPool(2, r -> {
+            Thread t = new Thread(r, "IPVersion-" + System.currentTimeMillis());
+            t.setDaemon(true);
+            return t;
+        });
     
     // Semaphore for rate limiting
     private static final Semaphore rateLimitSemaphore = new Semaphore(MAX_CONCURRENT_NETWORK_VALIDATIONS);
@@ -414,12 +435,215 @@ public class NetworkValidationCoordinator {
     }
     
     /**
+     * Results container for IP version validation execution.
+     */
+    public static class IPVersionValidationResults {
+        private final Map<String, Integer> results = new ConcurrentHashMap<>();
+        
+        public void addResult(String key, int validationResult) {
+            results.put(key, validationResult);
+        }
+        
+        public int getResult(String key) {
+            return results.getOrDefault(key, -1);
+        }
+        
+        public Map<String, Integer> getAllResults() {
+            return new HashMap<>(results);
+        }
+        
+        public boolean allSuccessful() {
+            return results.values().stream().allMatch(result -> result == 0);
+        }
+    }
+    
+    /**
+     * Execute validations for both IP versions in parallel if enabled.
+     * This method coordinates the high-level IPv4/IPv6 split.
+     */
+    public static IPVersionValidationResults executeIPVersionValidations(
+            ValidatorWorkflow validator,
+            URI uri,
+            boolean executeIPv4,
+            boolean executeIPv6,
+            BiConsumer<String, String> progressCallback) {
+        
+        if (!PARALLEL_IP_VERSIONS_ENABLED) {
+            logger.info("IP version parallelization disabled, falling back to sequential execution");
+            return executeIPVersionsSequentially(validator, uri, executeIPv4, executeIPv6, progressCallback);
+        }
+        
+        logger.info("Executing IPv4 and IPv6 validations in parallel");
+        
+        IPVersionValidationResults allResults = new IPVersionValidationResults();
+        List<CompletableFuture<Void>> ipVersionFutures = new ArrayList<>();
+        
+        // IPv6 execution
+        if (executeIPv6 && DNSCacheResolver.hasV6Addresses(uri.toString())) {
+            CompletableFuture<Void> ipv6Future = CompletableFuture.runAsync(() -> {
+                IPVersionContext ipv6Context = new IPVersionContext(NetworkProtocol.IPv6);
+                
+                try {
+                    ipv6Context.activate();
+                    NetworkInfo.setStackToV6();
+                    logger.info("Starting IPv6 validations in parallel thread");
+                    
+                    // Execute JSON validation
+                    progressCallback.accept("IPv6", "JSON");
+                    NetworkInfo.setAcceptHeaderToApplicationJson();
+                    int jsonResult = validator.validate();
+                    allResults.addResult("IPv6-JSON", jsonResult);
+                    logger.debug("IPv6 JSON validation result: {}", jsonResult);
+                    
+                    // Execute RDAP+JSON validation
+                    progressCallback.accept("IPv6", "RDAP+JSON");
+                    NetworkInfo.setAcceptHeaderToApplicationRdapJson();
+                    int rdapJsonResult = validator.validate();
+                    allResults.addResult("IPv6-RDAP+JSON", rdapJsonResult);
+                    logger.debug("IPv6 RDAP+JSON validation result: {}", rdapJsonResult);
+                    
+                    logger.info("Completed IPv6 validations in parallel thread");
+                    
+                } catch (Exception e) {
+                    logger.error("Error during IPv6 parallel validation", e);
+                    allResults.addResult("IPv6-JSON", -1);
+                    allResults.addResult("IPv6-RDAP+JSON", -1);
+                } finally {
+                    ipv6Context.deactivate();
+                }
+            }, ipVersionExecutor);
+            
+            ipVersionFutures.add(ipv6Future);
+        }
+        
+        // IPv4 execution
+        if (executeIPv4 && DNSCacheResolver.hasV4Addresses(uri.toString())) {
+            CompletableFuture<Void> ipv4Future = CompletableFuture.runAsync(() -> {
+                IPVersionContext ipv4Context = new IPVersionContext(NetworkProtocol.IPv4);
+                
+                try {
+                    ipv4Context.activate();
+                    NetworkInfo.setStackToV4();
+                    logger.info("Starting IPv4 validations in parallel thread");
+                    
+                    // Execute JSON validation
+                    progressCallback.accept("IPv4", "JSON");
+                    NetworkInfo.setAcceptHeaderToApplicationJson();
+                    int jsonResult = validator.validate();
+                    allResults.addResult("IPv4-JSON", jsonResult);
+                    logger.debug("IPv4 JSON validation result: {}", jsonResult);
+                    
+                    // Execute RDAP+JSON validation
+                    progressCallback.accept("IPv4", "RDAP+JSON");
+                    NetworkInfo.setAcceptHeaderToApplicationRdapJson();
+                    int rdapJsonResult = validator.validate();
+                    allResults.addResult("IPv4-RDAP+JSON", rdapJsonResult);
+                    logger.debug("IPv4 RDAP+JSON validation result: {}", rdapJsonResult);
+                    
+                    logger.info("Completed IPv4 validations in parallel thread");
+                    
+                } catch (Exception e) {
+                    logger.error("Error during IPv4 parallel validation", e);
+                    allResults.addResult("IPv4-JSON", -1);
+                    allResults.addResult("IPv4-RDAP+JSON", -1);
+                } finally {
+                    ipv4Context.deactivate();
+                }
+            }, ipVersionExecutor);
+            
+            ipVersionFutures.add(ipv4Future);
+        }
+        
+        if (!ipVersionFutures.isEmpty()) {
+            // Wait for all IP version validations to complete
+            CompletableFuture<Void> allVersions = CompletableFuture.allOf(
+                ipVersionFutures.toArray(new CompletableFuture[0]));
+            
+            try {
+                allVersions.get(300, TimeUnit.SECONDS); // 5 minute timeout
+                logger.info("All parallel IP version validations completed successfully");
+            } catch (Exception e) {
+                logger.error("Error during parallel IP version execution", e);
+                ipVersionFutures.forEach(f -> f.cancel(true));
+            }
+        }
+        
+        return allResults;
+    }
+    
+    /**
+     * Sequential execution fallback for IP version validations.
+     */
+    private static IPVersionValidationResults executeIPVersionsSequentially(
+            ValidatorWorkflow validator,
+            URI uri,
+            boolean executeIPv4,
+            boolean executeIPv6,
+            BiConsumer<String, String> progressCallback) {
+        
+        IPVersionValidationResults results = new IPVersionValidationResults();
+        
+        // IPv6 execution
+        if (executeIPv6 && DNSCacheResolver.hasV6Addresses(uri.toString())) {
+            NetworkInfo.setStackToV6();
+            
+            try {
+                progressCallback.accept("IPv6", "JSON");
+                NetworkInfo.setAcceptHeaderToApplicationJson();
+                int v6JsonResult = validator.validate();
+                results.addResult("IPv6-JSON", v6JsonResult);
+            } catch (Exception e) {
+                logger.error("Error during IPv6 JSON validation in sequential mode", e);
+                results.addResult("IPv6-JSON", -1);
+            }
+            
+            try {
+                progressCallback.accept("IPv6", "RDAP+JSON");
+                NetworkInfo.setAcceptHeaderToApplicationRdapJson();
+                int v6RdapResult = validator.validate();
+                results.addResult("IPv6-RDAP+JSON", v6RdapResult);
+            } catch (Exception e) {
+                logger.error("Error during IPv6 RDAP+JSON validation in sequential mode", e);
+                results.addResult("IPv6-RDAP+JSON", -1);
+            }
+        }
+        
+        // IPv4 execution
+        if (executeIPv4 && DNSCacheResolver.hasV4Addresses(uri.toString())) {
+            NetworkInfo.setStackToV4();
+            
+            try {
+                progressCallback.accept("IPv4", "JSON");
+                NetworkInfo.setAcceptHeaderToApplicationJson();
+                int v4JsonResult = validator.validate();
+                results.addResult("IPv4-JSON", v4JsonResult);
+            } catch (Exception e) {
+                logger.error("Error during IPv4 JSON validation in sequential mode", e);
+                results.addResult("IPv4-JSON", -1);
+            }
+            
+            try {
+                progressCallback.accept("IPv4", "RDAP+JSON");
+                NetworkInfo.setAcceptHeaderToApplicationRdapJson();
+                int v4RdapResult = validator.validate();
+                results.addResult("IPv4-RDAP+JSON", v4RdapResult);
+            } catch (Exception e) {
+                logger.error("Error during IPv4 RDAP+JSON validation in sequential mode", e);
+                results.addResult("IPv4-RDAP+JSON", -1);
+            }
+        }
+        
+        return results;
+    }
+    
+    /**
      * Shutdown the network validation executors.
      * Should be called when the application is shutting down.
      */
     public static void shutdown() {
         networkExecutor.shutdown();
         httpExecutor.shutdown();
+        ipVersionExecutor.shutdown();
         try {
             if (!networkExecutor.awaitTermination(30, TimeUnit.SECONDS)) {
                 networkExecutor.shutdownNow();
@@ -427,10 +651,14 @@ public class NetworkValidationCoordinator {
             if (!httpExecutor.awaitTermination(30, TimeUnit.SECONDS)) {
                 httpExecutor.shutdownNow();
             }
+            if (!ipVersionExecutor.awaitTermination(30, TimeUnit.SECONDS)) {
+                ipVersionExecutor.shutdownNow();
+            }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             networkExecutor.shutdownNow();
             httpExecutor.shutdownNow();
+            ipVersionExecutor.shutdownNow();
         }
     }
 }

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidatorResultsImpl.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidatorResultsImpl.java
@@ -6,6 +6,7 @@ import static org.icann.rdapconformance.validator.CommonUtils.ZERO;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,9 +27,9 @@ public class RDAPValidatorResultsImpl implements RDAPValidatorResults {
   // Static instance for the singleton
   private static RDAPValidatorResultsImpl instance;
 
-  private final Set<RDAPValidationResult> results = new HashSet<>();
-  private final Set<String> groups = new HashSet<>();
-  private final Set<String> groupErrorWarning = new HashSet<>();
+  private final Set<RDAPValidationResult> results = ConcurrentHashMap.newKeySet();
+  private final Set<String> groups = ConcurrentHashMap.newKeySet();
+  private final Set<String> groupErrorWarning = ConcurrentHashMap.newKeySet();
 
   // Private constructor to prevent instantiation
   private RDAPValidatorResultsImpl() {}

--- a/validator/src/test/java/org/icann/rdapconformance/validator/DNSCacheResolverTest.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/DNSCacheResolverTest.java
@@ -1,0 +1,461 @@
+package org.icann.rdapconformance.validator;
+
+import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidationResult;
+import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidatorResults;
+import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidatorResultsImpl;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.xbill.DNS.*;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+public class DNSCacheResolverTest {
+
+    @BeforeMethod
+    public void setUp() {
+        // Clear caches before each test
+        clearDNSCaches();
+        // Reset to default system DNS before each test
+        DNSCacheResolver.initializeResolver(null);
+        // Clear validation results
+        RDAPValidatorResultsImpl.getInstance().clear();
+    }
+
+    private void clearDNSCaches() {
+        // Use reflection to clear the private caches
+        try {
+            java.lang.reflect.Field cacheV4Field = DNSCacheResolver.class.getDeclaredField("CACHE_V4");
+            cacheV4Field.setAccessible(true);
+            Map<String, List<InetAddress>> cacheV4 = (Map<String, List<InetAddress>>) cacheV4Field.get(null);
+            cacheV4.clear();
+
+            java.lang.reflect.Field cacheV6Field = DNSCacheResolver.class.getDeclaredField("CACHE_V6");
+            cacheV6Field.setAccessible(true);
+            Map<String, List<InetAddress>> cacheV6 = (Map<String, List<InetAddress>>) cacheV6Field.get(null);
+            cacheV6.clear();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to clear DNS caches", e);
+        }
+    }
+
+    // ===========================================
+    // Tests for initializeResolver method
+    // ===========================================
+
+    @Test
+    public void testInitializeResolver_WithNullCustomServer_UsesExtendedResolver() {
+        DNSCacheResolver.initializeResolver(null);
+        
+        assertThat(DNSCacheResolver.resolver).isNotNull();
+        assertThat(DNSCacheResolver.resolver).isInstanceOf(ExtendedResolver.class);
+    }
+
+    @Test
+    public void testInitializeResolver_WithEmptyCustomServer_UsesExtendedResolver() {
+        DNSCacheResolver.initializeResolver("");
+        
+        assertThat(DNSCacheResolver.resolver).isNotNull();
+        assertThat(DNSCacheResolver.resolver).isInstanceOf(ExtendedResolver.class);
+    }
+
+    @Test
+    public void testInitializeResolver_WithValidIPv4Address_UsesSimpleResolver() {
+        DNSCacheResolver.initializeResolver("8.8.8.8");
+        
+        assertThat(DNSCacheResolver.resolver).isNotNull();
+        assertThat(DNSCacheResolver.resolver).isInstanceOf(SimpleResolver.class);
+    }
+
+    @Test
+    public void testInitializeResolver_WithValidIPv6Address_UsesSimpleResolver() {
+        DNSCacheResolver.initializeResolver("2001:4860:4860::8888");
+        
+        assertThat(DNSCacheResolver.resolver).isNotNull();
+        assertThat(DNSCacheResolver.resolver).isInstanceOf(SimpleResolver.class);
+    }
+
+    @Test
+    public void testInitializeResolver_WithLocalhostIPv4_UsesSimpleResolver() {
+        DNSCacheResolver.initializeResolver("127.0.0.1");
+        
+        assertThat(DNSCacheResolver.resolver).isNotNull();
+        assertThat(DNSCacheResolver.resolver).isInstanceOf(SimpleResolver.class);
+    }
+
+    @Test
+    public void testInitializeResolver_WithLocalhostIPv6_UsesSimpleResolver() {
+        DNSCacheResolver.initializeResolver("::1");
+        
+        assertThat(DNSCacheResolver.resolver).isNotNull();
+        assertThat(DNSCacheResolver.resolver).isInstanceOf(SimpleResolver.class);
+    }
+
+    @Test
+    public void testInitializeResolver_WithInvalidIPAddress_ThrowsException() {
+        assertThatThrownBy(() -> DNSCacheResolver.initializeResolver("invalid.dns.server"))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessageContaining("Invalid DNS resolver configuration");
+    }
+
+    @Test
+    public void testInitializeResolver_WithInvalidIPv4Format_ThrowsException() {
+        assertThatThrownBy(() -> DNSCacheResolver.initializeResolver("300.300.300.300"))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessageContaining("Invalid DNS resolver configuration");
+    }
+
+    @Test
+    public void testInitializeResolver_WithInvalidIPv6Format_ThrowsException() {
+        assertThatThrownBy(() -> DNSCacheResolver.initializeResolver("gggg::1"))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessageContaining("Invalid DNS resolver configuration");
+    }
+
+    // ===========================================
+    // Tests for URL hostname extraction
+    // ===========================================
+
+    @Test
+    public void testGetHostnameFromUrl_ValidHttp() {
+        String hostname = DNSCacheResolver.getHostnameFromUrl("http://example.com/path");
+        assertThat(hostname).isEqualTo("example.com");
+    }
+
+    @Test
+    public void testGetHostnameFromUrl_ValidHttps() {
+        String hostname = DNSCacheResolver.getHostnameFromUrl("https://rdap.example.com/domain/test.com");
+        assertThat(hostname).isEqualTo("rdap.example.com");
+    }
+
+    @Test
+    public void testGetHostnameFromUrl_WithPort() {
+        String hostname = DNSCacheResolver.getHostnameFromUrl("https://example.com:8080/path");
+        assertThat(hostname).isEqualTo("example.com");
+    }
+
+    @Test
+    public void testGetHostnameFromUrl_WithIPv4() {
+        String hostname = DNSCacheResolver.getHostnameFromUrl("http://192.168.1.1/path");
+        assertThat(hostname).isEqualTo("192.168.1.1");
+    }
+
+    @Test
+    public void testGetHostnameFromUrl_WithIPv6() {
+        String hostname = DNSCacheResolver.getHostnameFromUrl("http://[2001:db8::1]/path");
+        assertThat(hostname).isEqualTo("[2001:db8::1]"); // IPv6 addresses include brackets
+    }
+
+    @Test
+    public void testGetHostnameFromUrl_InvalidUrl() {
+        String hostname = DNSCacheResolver.getHostnameFromUrl("not-a-valid-url");
+        assertThat(hostname).isEmpty();
+    }
+
+    @Test
+    public void testGetHostnameFromUrl_NullUrl() {
+        // This will throw NullPointerException as the method doesn't handle null
+        assertThatThrownBy(() -> DNSCacheResolver.getHostnameFromUrl(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    public void testGetHostnameFromUrl_EmptyUrl() {
+        String hostname = DNSCacheResolver.getHostnameFromUrl("");
+        assertThat(hostname).isEmpty();
+    }
+
+    // ===========================================
+    // Tests for FQDN handling
+    // ===========================================
+
+    @Test
+    public void testEnsureFQDN_WithoutDot() {
+        String fqdn = DNSCacheResolver.ensureFQDN("example.com");
+        assertThat(fqdn).isEqualTo("example.com.");
+    }
+
+    @Test
+    public void testEnsureFQDN_WithDot() {
+        String fqdn = DNSCacheResolver.ensureFQDN("example.com.");
+        assertThat(fqdn).isEqualTo("example.com.");
+    }
+
+    @Test
+    public void testEnsureFQDN_EmptyString() {
+        String fqdn = DNSCacheResolver.ensureFQDN("");
+        assertThat(fqdn).isEqualTo(".");
+    }
+
+    @Test
+    public void testEnsureFQDN_SingleDot() {
+        String fqdn = DNSCacheResolver.ensureFQDN(".");
+        assertThat(fqdn).isEqualTo(".");
+    }
+
+    // ===========================================
+    // Tests for getFirst utility method
+    // ===========================================
+
+    @Test
+    public void testGetFirst_WithEmptyMap() {
+        Map<String, List<InetAddress>> cache = java.util.Map.of();
+        InetAddress result = DNSCacheResolver.getFirst(cache, "example.com.");
+        assertThat(result).isNull();
+    }
+
+    @Test
+    public void testGetFirst_WithEmptyList() throws UnknownHostException {
+        Map<String, List<InetAddress>> cache = java.util.Map.of("example.com.", java.util.List.of());
+        InetAddress result = DNSCacheResolver.getFirst(cache, "example.com.");
+        assertThat(result).isNull();
+    }
+
+    @Test
+    public void testGetFirst_WithNonEmptyList() throws UnknownHostException {
+        InetAddress addr1 = InetAddress.getByName("192.168.1.1");
+        InetAddress addr2 = InetAddress.getByName("192.168.1.2");
+        Map<String, List<InetAddress>> cache = java.util.Map.of("example.com.", java.util.List.of(addr1, addr2));
+        InetAddress result = DNSCacheResolver.getFirst(cache, "example.com.");
+        assertThat(result).isEqualTo(addr1);
+    }
+
+    @Test
+    public void testGetFirst_WithNullKey() {
+        Map<String, List<InetAddress>> cache = java.util.Map.of();
+        // This will throw NullPointerException as Map.get(null) throws NPE
+        assertThatThrownBy(() -> DNSCacheResolver.getFirst(cache, null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // ===========================================
+    // Tests for initFromUrl
+    // ===========================================
+
+    @Test
+    public void testInitFromUrl_ValidUrl() {
+        // This should not throw an exception
+        DNSCacheResolver.initFromUrl("http://example.com/path");
+        // The method should complete successfully
+    }
+
+    @Test
+    public void testInitFromUrl_InvalidUrl() {
+        // This should not throw an exception, just log an error
+        DNSCacheResolver.initFromUrl("invalid-url");
+        // The method should complete successfully
+    }
+
+    @Test
+    public void testInitFromUrl_NullUrl() {
+        // This will throw NullPointerException as URI constructor doesn't handle null
+        assertThatThrownBy(() -> DNSCacheResolver.initFromUrl(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    public void testInitFromUrl_UrlWithoutHost() {
+        // This should not throw an exception
+        DNSCacheResolver.initFromUrl("file:///path/to/file");
+        // The method should complete successfully
+    }
+
+    // ===========================================
+    // Tests for localhost special cases
+    // ===========================================
+
+    @Test
+    public void testResolveIfNeeded_Localhost() {
+        DNSCacheResolver.resolveIfNeeded("localhost.");
+        
+        // Should have cached results for both IPv4 and IPv6
+        List<InetAddress> v4Addresses = DNSCacheResolver.getAllV4Addresses("localhost.");
+        List<InetAddress> v6Addresses = DNSCacheResolver.getAllV6Addresses("localhost.");
+        
+        assertThat(v4Addresses).isNotEmpty();
+        assertThat(v6Addresses).isNotEmpty();
+        
+        // Should resolve to loopback addresses
+        assertThat(v4Addresses.get(0).getHostAddress()).isEqualTo("127.0.0.1");
+        assertThat(v6Addresses.get(0).getHostAddress()).isEqualTo("0:0:0:0:0:0:0:1");
+    }
+
+    @Test
+    public void testResolveIfNeeded_127001() {
+        DNSCacheResolver.resolveIfNeeded("127.0.0.1.");
+        
+        List<InetAddress> v4Addresses = DNSCacheResolver.getAllV4Addresses("127.0.0.1.");
+        assertThat(v4Addresses).isNotEmpty();
+        assertThat(v4Addresses.get(0).getHostAddress()).isEqualTo("127.0.0.1");
+    }
+
+    @Test
+    public void testResolveIfNeeded_IPv6Localhost() {
+        DNSCacheResolver.resolveIfNeeded("::1.");
+        
+        List<InetAddress> v6Addresses = DNSCacheResolver.getAllV6Addresses("::1.");
+        // ::1 might not always resolve properly in all environments, so check if empty is acceptable
+        if (!v6Addresses.isEmpty()) {
+            assertThat(v6Addresses.get(0).getHostAddress()).isEqualTo("0:0:0:0:0:0:0:1");
+        }
+    }
+
+    // ===========================================
+    // Tests for address checking methods
+    // ===========================================
+
+    @Test
+    public void testHasV4Addresses_WithLocalhostUrl() {
+        boolean hasV4 = DNSCacheResolver.hasV4Addresses("http://localhost/");
+        assertThat(hasV4).isTrue();
+    }
+
+    @Test
+    public void testHasV6Addresses_WithLocalhostUrl() {
+        boolean hasV6 = DNSCacheResolver.hasV6Addresses("http://localhost/");
+        assertThat(hasV6).isTrue();
+    }
+
+    @Test
+    public void testHasNoAddresses_WithLocalhostFqdn() {
+        boolean hasNone = DNSCacheResolver.hasNoAddresses("localhost");
+        assertThat(hasNone).isFalse(); // localhost should have addresses
+    }
+
+    @Test
+    public void testHasV4Addresses_WithIPv4Url() {
+        boolean hasV4 = DNSCacheResolver.hasV4Addresses("http://127.0.0.1/");
+        assertThat(hasV4).isTrue();
+    }
+
+    @Test
+    public void testHasV6Addresses_WithIPv6Url() {
+        boolean hasV6 = DNSCacheResolver.hasV6Addresses("http://[::1]/");
+        // IPv6 localhost might not always be available, so this might be false
+        // Let's just check the method doesn't throw an exception
+        assertThat(hasV6).isIn(true, false);
+    }
+
+    @Test
+    public void testGetFirstV4Address_WithLocalhost() {
+        InetAddress addr = DNSCacheResolver.getFirstV4Address("localhost");
+        assertThat(addr).isNotNull();
+        assertThat(addr.getHostAddress()).isEqualTo("127.0.0.1");
+    }
+
+    @Test
+    public void testGetFirstV6Address_WithLocalhost() {
+        InetAddress addr = DNSCacheResolver.getFirstV6Address("localhost");
+        assertThat(addr).isNotNull();
+        assertThat(addr.getHostAddress()).isEqualTo("0:0:0:0:0:0:0:1");
+    }
+
+    // ===========================================
+    // Tests for validation methods
+    // ===========================================
+
+    @Test
+    public void testDoZeroIPAddressesValidation_BothProtocols_LocalhostUrl() {
+        DNSCacheResolver.doZeroIPAddressesValidation("http://localhost/", true, true);
+        
+        // Should not add any validation errors since localhost has both IPv4 and IPv6
+        Set<RDAPValidationResult> results = RDAPValidatorResultsImpl.getInstance().getAll();
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    public void testDoZeroIPAddressesValidation_OnlyIPv4_LocalhostUrl() {
+        DNSCacheResolver.doZeroIPAddressesValidation("http://localhost/", false, true);
+        
+        // Should not add validation errors since localhost has IPv4
+        Set<RDAPValidationResult> results = RDAPValidatorResultsImpl.getInstance().getAll();
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    public void testDoZeroIPAddressesValidation_OnlyIPv6_LocalhostUrl() {
+        DNSCacheResolver.doZeroIPAddressesValidation("http://localhost/", true, false);
+        
+        // Should not add validation errors since localhost has IPv6
+        Set<RDAPValidationResult> results = RDAPValidatorResultsImpl.getInstance().getAll();
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    public void testDoZeroIPAddressesValidation_EmptyHostname() {
+        DNSCacheResolver.doZeroIPAddressesValidation("not-a-url", true, true);
+        
+        // Should add validation error for unable to resolve
+        Set<RDAPValidationResult> results = RDAPValidatorResultsImpl.getInstance().getAll();
+        assertThat(results).hasSize(1);
+        assertThat(results.iterator().next().getCode()).isEqualTo(-13019);
+    }
+
+    // ===========================================
+    // Tests for cache behavior
+    // ===========================================
+
+    @Test
+    public void testResolveIfNeeded_CacheHit() {
+        // First call should populate cache
+        DNSCacheResolver.resolveIfNeeded("localhost.");
+        List<InetAddress> firstResult = DNSCacheResolver.getAllV4Addresses("localhost.");
+        
+        // Second call should use cache
+        DNSCacheResolver.resolveIfNeeded("localhost.");
+        List<InetAddress> secondResult = DNSCacheResolver.getAllV4Addresses("localhost.");
+        
+        // Results should be the same (cached)
+        assertThat(firstResult).isEqualTo(secondResult);
+    }
+
+    @Test
+    public void testGetAllV4Addresses_EmptyResult() {
+        // Using a hostname that won't resolve to IPv4
+        List<InetAddress> addresses = DNSCacheResolver.getAllV4Addresses("nonexistent.invalid.tld");
+        assertThat(addresses).isEmpty();
+    }
+
+    @Test
+    public void testGetAllV6Addresses_EmptyResult() {
+        // Using a hostname that won't resolve to IPv6
+        List<InetAddress> addresses = DNSCacheResolver.getAllV6Addresses("nonexistent.invalid.tld");
+        assertThat(addresses).isEmpty();
+    }
+
+    // ===========================================
+    // Tests for error handling
+    // ===========================================
+
+    @Test
+    public void testResolveWithCNAMEChain_TypeA() {
+        // Test with localhost which should resolve directly - but through DNS, not special case
+        List<InetAddress> addresses = DNSCacheResolver.resolveWithCNAMEChain("example.com.", Type.A);
+        // This might be empty if DNS resolution fails or domain doesn't exist
+        // The important thing is the method doesn't throw an exception
+        assertThat(addresses).isNotNull();
+    }
+
+    @Test
+    public void testResolveWithCNAMEChain_TypeAAAA() {
+        // Test with example.com which might resolve to IPv6
+        List<InetAddress> addresses = DNSCacheResolver.resolveWithCNAMEChain("example.com.", Type.AAAA);
+        // This might be empty if DNS resolution fails or domain doesn't have IPv6
+        // The important thing is the method doesn't throw an exception
+        assertThat(addresses).isNotNull();
+    }
+
+    @Test
+    public void testResolveWithCNAMEChain_InvalidDomain() {
+        // Test with invalid domain - should return empty list, not throw exception
+        List<InetAddress> addresses = DNSCacheResolver.resolveWithCNAMEChain("nonexistent.invalid.tld.", Type.A);
+        assertThat(addresses).isEmpty();
+    }
+}

--- a/validator/src/test/java/org/icann/rdapconformance/validator/NetworkInfoTest.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/NetworkInfoTest.java
@@ -119,48 +119,14 @@ public class NetworkInfoTest {
     
     @Test
     public void testSetStackToV6() {
-        String originalIPv4Addresses = System.getProperty("java.net.preferIPv4Addresses");
-        String originalIPv4Stack = System.getProperty("java.net.preferIPv4Stack");
-        String originalIPv6Addresses = System.getProperty("java.net.preferIPv6Addresses");
-        String originalIPv6Stack = System.getProperty("java.net.preferIPv6Stack");
-        
-        try {
-            NetworkInfo.setStackToV6();
-            
-            assertThat(NetworkInfo.getNetworkProtocol()).isEqualTo(NetworkProtocol.IPv6);
-            assertThat(System.getProperty("java.net.preferIPv4Addresses")).isEqualTo("false");
-            assertThat(System.getProperty("java.net.preferIPv4Stack")).isEqualTo("false");
-            assertThat(System.getProperty("java.net.preferIPv6Addresses")).isEqualTo("true");
-            assertThat(System.getProperty("java.net.preferIPv6Stack")).isEqualTo("true");
-        } finally {
-            restoreSystemProperty("java.net.preferIPv4Addresses", originalIPv4Addresses);
-            restoreSystemProperty("java.net.preferIPv4Stack", originalIPv4Stack);
-            restoreSystemProperty("java.net.preferIPv6Addresses", originalIPv6Addresses);
-            restoreSystemProperty("java.net.preferIPv6Stack", originalIPv6Stack);
-        }
+        NetworkInfo.setStackToV6();
+        assertThat(NetworkInfo.getNetworkProtocol()).isEqualTo(NetworkProtocol.IPv6);
     }
     
     @Test
     public void testSetStackToV4() {
-        String originalIPv4Addresses = System.getProperty("java.net.preferIPv4Addresses");
-        String originalIPv4Stack = System.getProperty("java.net.preferIPv4Stack");
-        String originalIPv6Addresses = System.getProperty("java.net.preferIPv6Addresses");
-        String originalIPv6Stack = System.getProperty("java.net.preferIPv6Stack");
-        
-        try {
-            NetworkInfo.setStackToV4();
-            
-            assertThat(NetworkInfo.getNetworkProtocol()).isEqualTo(NetworkProtocol.IPv4);
-            assertThat(System.getProperty("java.net.preferIPv6Addresses")).isEqualTo("false");
-            assertThat(System.getProperty("java.net.preferIPv6Stack")).isEqualTo("false");
-            assertThat(System.getProperty("java.net.preferIPv4Addresses")).isEqualTo("true");
-            assertThat(System.getProperty("java.net.preferIPv4Stack")).isEqualTo("true");
-        } finally {
-            restoreSystemProperty("java.net.preferIPv4Addresses", originalIPv4Addresses);
-            restoreSystemProperty("java.net.preferIPv4Stack", originalIPv4Stack);
-            restoreSystemProperty("java.net.preferIPv6Addresses", originalIPv6Addresses);
-            restoreSystemProperty("java.net.preferIPv6Stack", originalIPv6Stack);
-        }
+        NetworkInfo.setStackToV4();
+        assertThat(NetworkInfo.getNetworkProtocol()).isEqualTo(NetworkProtocol.IPv4);
     }
     
     @Test
@@ -176,11 +142,4 @@ public class NetworkInfoTest {
         assertThat(NetworkInfo.getServerIpAddress()).isEqualTo("10.0.0.1");
     }
     
-    private void restoreSystemProperty(String key, String originalValue) {
-        if (originalValue == null) {
-            System.clearProperty(key);
-        } else {
-            System.setProperty(key, originalValue);
-        }
-    }
 }

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/IPVersionContextTest.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/IPVersionContextTest.java
@@ -29,10 +29,6 @@ public class IPVersionContextTest {
         assertThat(context.isActive()).isTrue();
         assertThat(IPVersionContext.current()).isEqualTo(context);
         
-        // Check system properties are set for IPv4
-        assertThat(System.getProperty("java.net.preferIPv4Addresses")).isEqualTo("true");
-        assertThat(System.getProperty("java.net.preferIPv6Addresses")).isEqualTo("false");
-        
         context.deactivate();
         
         assertThat(context.isActive()).isFalse();
@@ -51,10 +47,6 @@ public class IPVersionContextTest {
         assertThat(context.isActive()).isTrue();
         assertThat(IPVersionContext.current()).isEqualTo(context);
         
-        // Check system properties are set for IPv6
-        assertThat(System.getProperty("java.net.preferIPv6Addresses")).isEqualTo("true");
-        assertThat(System.getProperty("java.net.preferIPv4Addresses")).isEqualTo("false");
-        
         context.deactivate();
         
         assertThat(context.isActive()).isFalse();
@@ -62,23 +54,20 @@ public class IPVersionContextTest {
     }
     
     @Test
-    public void testIPVersionContext_PropertyRestoration() {
-        // Set initial values
-        System.setProperty("java.net.preferIPv4Addresses", "initial_ipv4");
-        System.setProperty("java.net.preferIPv6Addresses", "initial_ipv6");
-        
+    public void testIPVersionContext_ContextLifecycle() {
         IPVersionContext context = new IPVersionContext(NetworkProtocol.IPv6);
-        context.activate();
         
-        // Properties should be changed
-        assertThat(System.getProperty("java.net.preferIPv6Addresses")).isEqualTo("true");
-        assertThat(System.getProperty("java.net.preferIPv4Addresses")).isEqualTo("false");
+        // Verify context lifecycle works correctly
+        assertThat(context.isActive()).isFalse();
+        assertThat(IPVersionContext.current()).isNull();
+        
+        context.activate();
+        assertThat(context.isActive()).isTrue();
+        assertThat(IPVersionContext.current()).isEqualTo(context);
         
         context.deactivate();
-        
-        // Properties should be restored
-        assertThat(System.getProperty("java.net.preferIPv4Addresses")).isEqualTo("initial_ipv4");
-        assertThat(System.getProperty("java.net.preferIPv6Addresses")).isEqualTo("initial_ipv6");
+        assertThat(context.isActive()).isFalse();
+        assertThat(IPVersionContext.current()).isNull();
     }
     
     @Test

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/IPVersionContextTest.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/IPVersionContextTest.java
@@ -1,0 +1,117 @@
+package org.icann.rdapconformance.validator.workflow.profile;
+
+import org.icann.rdapconformance.validator.NetworkProtocol;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class IPVersionContextTest {
+    
+    @AfterMethod
+    public void cleanup() {
+        // Clear any active context after each test
+        IPVersionContext current = IPVersionContext.current();
+        if (current != null) {
+            current.deactivate();
+        }
+    }
+    
+    @Test
+    public void testIPVersionContext_IPv4Activation() {
+        IPVersionContext context = new IPVersionContext(NetworkProtocol.IPv4);
+        
+        assertThat(context.getProtocol()).isEqualTo(NetworkProtocol.IPv4);
+        assertThat(context.isActive()).isFalse();
+        
+        context.activate();
+        
+        assertThat(context.isActive()).isTrue();
+        assertThat(IPVersionContext.current()).isEqualTo(context);
+        
+        // Check system properties are set for IPv4
+        assertThat(System.getProperty("java.net.preferIPv4Addresses")).isEqualTo("true");
+        assertThat(System.getProperty("java.net.preferIPv6Addresses")).isEqualTo("false");
+        
+        context.deactivate();
+        
+        assertThat(context.isActive()).isFalse();
+        assertThat(IPVersionContext.current()).isNull();
+    }
+    
+    @Test
+    public void testIPVersionContext_IPv6Activation() {
+        IPVersionContext context = new IPVersionContext(NetworkProtocol.IPv6);
+        
+        assertThat(context.getProtocol()).isEqualTo(NetworkProtocol.IPv6);
+        assertThat(context.isActive()).isFalse();
+        
+        context.activate();
+        
+        assertThat(context.isActive()).isTrue();
+        assertThat(IPVersionContext.current()).isEqualTo(context);
+        
+        // Check system properties are set for IPv6
+        assertThat(System.getProperty("java.net.preferIPv6Addresses")).isEqualTo("true");
+        assertThat(System.getProperty("java.net.preferIPv4Addresses")).isEqualTo("false");
+        
+        context.deactivate();
+        
+        assertThat(context.isActive()).isFalse();
+        assertThat(IPVersionContext.current()).isNull();
+    }
+    
+    @Test
+    public void testIPVersionContext_PropertyRestoration() {
+        // Set initial values
+        System.setProperty("java.net.preferIPv4Addresses", "initial_ipv4");
+        System.setProperty("java.net.preferIPv6Addresses", "initial_ipv6");
+        
+        IPVersionContext context = new IPVersionContext(NetworkProtocol.IPv6);
+        context.activate();
+        
+        // Properties should be changed
+        assertThat(System.getProperty("java.net.preferIPv6Addresses")).isEqualTo("true");
+        assertThat(System.getProperty("java.net.preferIPv4Addresses")).isEqualTo("false");
+        
+        context.deactivate();
+        
+        // Properties should be restored
+        assertThat(System.getProperty("java.net.preferIPv4Addresses")).isEqualTo("initial_ipv4");
+        assertThat(System.getProperty("java.net.preferIPv6Addresses")).isEqualTo("initial_ipv6");
+    }
+    
+    @Test
+    public void testIPVersionContext_MultipleContexts() {
+        IPVersionContext context1 = new IPVersionContext(NetworkProtocol.IPv4);
+        IPVersionContext context2 = new IPVersionContext(NetworkProtocol.IPv6);
+        
+        // Only one context can be active per thread
+        context1.activate();
+        assertThat(IPVersionContext.current()).isEqualTo(context1);
+        
+        context2.activate();
+        assertThat(IPVersionContext.current()).isEqualTo(context2);
+        assertThat(context1.isActive()).isFalse();
+        assertThat(context2.isActive()).isTrue();
+        
+        context2.deactivate();
+        assertThat(IPVersionContext.current()).isNull();
+    }
+    
+    @Test
+    public void testIPVersionContext_ToString() {
+        IPVersionContext context = new IPVersionContext(NetworkProtocol.IPv4);
+        
+        String str = context.toString();
+        assertThat(str).contains("IPv4");
+        assertThat(str).contains("active=false");
+        
+        context.activate();
+        str = context.toString();
+        assertThat(str).contains("IPv4");
+        assertThat(str).contains("active=true");
+        
+        context.deactivate();
+    }
+}

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/NetworkValidationCoordinatorTest.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/NetworkValidationCoordinatorTest.java
@@ -2,10 +2,13 @@ package org.icann.rdapconformance.validator.workflow.profile;
 
 import org.icann.rdapconformance.validator.NetworkInfo;
 import org.icann.rdapconformance.validator.NetworkProtocol;
+import org.icann.rdapconformance.validator.DNSCacheResolver;
+import org.icann.rdapconformance.validator.workflow.ValidatorWorkflow;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -13,30 +16,47 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.atLeast;
 
 public class NetworkValidationCoordinatorTest {
 
     private String originalParallelProperty;
+    private String originalIPVersionsProperty;
 
     @BeforeMethod
     public void setUp() {
-        // Store original system property
+        // Store original system properties
         originalParallelProperty = System.getProperty("rdap.parallel.network");
+        originalIPVersionsProperty = System.getProperty("rdap.parallel.ipversions");
     }
 
     @AfterMethod
     public void tearDown() {
-        // Restore original system property
+        // Restore original system properties
         if (originalParallelProperty != null) {
             System.setProperty("rdap.parallel.network", originalParallelProperty);
         } else {
             System.clearProperty("rdap.parallel.network");
+        }
+        
+        if (originalIPVersionsProperty != null) {
+            System.setProperty("rdap.parallel.ipversions", originalIPVersionsProperty);
+        } else {
+            System.clearProperty("rdap.parallel.ipversions");
+        }
+        
+        // Clear any active IP version context
+        IPVersionContext current = IPVersionContext.current();
+        if (current != null) {
+            current.deactivate();
         }
     }
 
@@ -691,5 +711,314 @@ public class NetworkValidationCoordinatorTest {
         public String getGroupName() {
             return "RegularValidation";
         }
+    }
+    
+    // === IP VERSION COORDINATION TESTS ===
+    
+    @Test
+    public void testExecuteIPVersionValidations_ParallelDisabled() throws Exception {
+        // Disable IP version parallelization
+        System.clearProperty("rdap.parallel.ipversions");
+        
+        ValidatorWorkflow mockValidator = mock(ValidatorWorkflow.class);
+        when(mockValidator.validate()).thenReturn(0); // Success
+        
+        URI testUri = new URI("https://example.com");
+        AtomicReference<String> capturedIPVersion = new AtomicReference<>();
+        AtomicReference<String> capturedAcceptHeader = new AtomicReference<>();
+        
+        BiConsumer<String, String> progressCallback = (ip, accept) -> {
+            capturedIPVersion.set(ip);
+            capturedAcceptHeader.set(accept);
+        };
+        
+        NetworkValidationCoordinator.IPVersionValidationResults results = 
+            NetworkValidationCoordinator.executeIPVersionValidations(
+                mockValidator, testUri, true, true, progressCallback);
+        
+        assertThat(results).isNotNull();
+        // The actual number of calls depends on DNS resolution
+        // We just verify that the method was called and results were collected
+        verify(mockValidator, atLeast(0)).validate();
+        assertThat(results.getAllResults()).isNotEmpty();
+    }
+    
+    @Test
+    public void testExecuteIPVersionValidations_ParallelEnabled() throws Exception {
+        // Enable IP version parallelization
+        System.setProperty("rdap.parallel.ipversions", "true");
+        
+        ValidatorWorkflow mockValidator = mock(ValidatorWorkflow.class);
+        when(mockValidator.validate()).thenReturn(0); // Success
+        when(mockValidator.getResultsPath()).thenReturn("/tmp/test-results");
+        
+        URI testUri = new URI("https://example.com");
+        AtomicInteger callbackCount = new AtomicInteger(0);
+        
+        BiConsumer<String, String> progressCallback = (ip, accept) -> {
+            callbackCount.incrementAndGet();
+        };
+        
+        NetworkValidationCoordinator.IPVersionValidationResults results = 
+            NetworkValidationCoordinator.executeIPVersionValidations(
+                mockValidator, testUri, true, true, progressCallback);
+        
+        assertThat(results).isNotNull();
+        // The actual number of calls depends on DNS resolution and parallelization
+        verify(mockValidator, atLeast(0)).validate();
+        assertThat(results.getAllResults()).isNotEmpty();
+    }
+    
+    @Test
+    public void testExecuteIPVersionValidations_IPv4Only() throws Exception {
+        System.setProperty("rdap.parallel.ipversions", "true");
+        
+        ValidatorWorkflow mockValidator = mock(ValidatorWorkflow.class);
+        when(mockValidator.validate()).thenReturn(0);
+        when(mockValidator.getResultsPath()).thenReturn("/tmp/test-results");
+        
+        URI testUri = new URI("https://example.com");
+        AtomicInteger callbackCount = new AtomicInteger(0);
+        AtomicReference<String> lastIpVersion = new AtomicReference<>();
+        
+        BiConsumer<String, String> progressCallback = (ip, accept) -> {
+            lastIpVersion.set(ip);
+            callbackCount.incrementAndGet();
+        };
+        
+        NetworkValidationCoordinator.IPVersionValidationResults results = 
+            NetworkValidationCoordinator.executeIPVersionValidations(
+                mockValidator, testUri, true, false, progressCallback); // IPv4 only
+        
+        assertThat(results).isNotNull();
+        // DNS resolution dependent - just verify structure works
+        verify(mockValidator, atLeast(0)).validate();
+        if (callbackCount.get() > 0) {
+            assertThat(lastIpVersion.get()).isEqualTo("IPv4");
+        }
+    }
+    
+    @Test
+    public void testExecuteIPVersionValidations_IPv6Only() throws Exception {
+        System.setProperty("rdap.parallel.ipversions", "true");
+        
+        ValidatorWorkflow mockValidator = mock(ValidatorWorkflow.class);
+        when(mockValidator.validate()).thenReturn(0);
+        when(mockValidator.getResultsPath()).thenReturn("/tmp/test-results");
+        
+        URI testUri = new URI("https://example.com");
+        AtomicInteger callbackCount = new AtomicInteger(0);
+        AtomicReference<String> lastIpVersion = new AtomicReference<>();
+        
+        BiConsumer<String, String> progressCallback = (ip, accept) -> {
+            lastIpVersion.set(ip);
+            callbackCount.incrementAndGet();
+        };
+        
+        NetworkValidationCoordinator.IPVersionValidationResults results = 
+            NetworkValidationCoordinator.executeIPVersionValidations(
+                mockValidator, testUri, false, true, progressCallback); // IPv6 only
+        
+        assertThat(results).isNotNull();
+        // DNS resolution dependent - just verify structure works
+        verify(mockValidator, atLeast(0)).validate();
+        if (callbackCount.get() > 0) {
+            assertThat(lastIpVersion.get()).isEqualTo("IPv6");
+        }
+    }
+    
+    @Test
+    public void testExecuteIPVersionValidations_ValidatorException() throws Exception {
+        System.setProperty("rdap.parallel.ipversions", "true");
+        
+        ValidatorWorkflow mockValidator = mock(ValidatorWorkflow.class);
+        when(mockValidator.validate()).thenThrow(new RuntimeException("Validation error"));
+        when(mockValidator.getResultsPath()).thenReturn("/tmp/test-results");
+        
+        URI testUri = new URI("https://example.com");
+        BiConsumer<String, String> progressCallback = (ip, accept) -> {};
+        
+        NetworkValidationCoordinator.IPVersionValidationResults results = 
+            NetworkValidationCoordinator.executeIPVersionValidations(
+                mockValidator, testUri, true, false, progressCallback);
+        
+        assertThat(results).isNotNull();
+        // Should handle exception gracefully - result should contain error codes
+        assertThat(results.getResult("IPv4-JSON")).isEqualTo(-1);
+        assertThat(results.getResult("IPv4-RDAP+JSON")).isEqualTo(-1);
+    }
+    
+    @Test
+    public void testIPVersionValidationResults_BasicOperations() {
+        NetworkValidationCoordinator.IPVersionValidationResults results = 
+            new NetworkValidationCoordinator.IPVersionValidationResults();
+        
+        // Test adding results
+        results.addResult("IPv4-JSON", 0);
+        results.addResult("IPv4-RDAP+JSON", 0);
+        results.addResult("IPv6-JSON", 1);
+        results.addResult("IPv6-RDAP+JSON", 0);
+        
+        // Test getting results
+        assertThat(results.getResult("IPv4-JSON")).isEqualTo(0);
+        assertThat(results.getResult("IPv4-RDAP+JSON")).isEqualTo(0);
+        assertThat(results.getResult("IPv6-JSON")).isEqualTo(1);
+        assertThat(results.getResult("IPv6-RDAP+JSON")).isEqualTo(0);
+        assertThat(results.getResult("NonExistent")).isEqualTo(-1);
+        
+        // Test getAllResults
+        assertThat(results.getAllResults()).hasSize(4);
+        assertThat(results.getAllResults()).containsKey("IPv4-JSON");
+        assertThat(results.getAllResults()).containsKey("IPv6-RDAP+JSON");
+        
+        // Test allSuccessful - should be false because IPv6-JSON returned 1
+        assertThat(results.allSuccessful()).isFalse();
+    }
+    
+    @Test
+    public void testIPVersionValidationResults_AllSuccessful() {
+        NetworkValidationCoordinator.IPVersionValidationResults results = 
+            new NetworkValidationCoordinator.IPVersionValidationResults();
+        
+        results.addResult("IPv4-JSON", 0);
+        results.addResult("IPv4-RDAP+JSON", 0);
+        results.addResult("IPv6-JSON", 0);
+        results.addResult("IPv6-RDAP+JSON", 0);
+        
+        assertThat(results.allSuccessful()).isTrue();
+    }
+    
+    @Test
+    public void testIPVersionValidationResults_ThreadSafety() throws InterruptedException {
+        NetworkValidationCoordinator.IPVersionValidationResults results = 
+            new NetworkValidationCoordinator.IPVersionValidationResults();
+        
+        int threadCount = 10;
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+        
+        // Start multiple threads adding results concurrently
+        for (int i = 0; i < threadCount; i++) {
+            final int threadId = i;
+            new Thread(() -> {
+                try {
+                    startLatch.await();
+                    for (int j = 0; j < 10; j++) {
+                        results.addResult("Thread" + threadId + "-Result" + j, j);
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    doneLatch.countDown();
+                }
+            }).start();
+        }
+        
+        startLatch.countDown(); // Start all threads
+        assertThat(doneLatch.await(5, TimeUnit.SECONDS)).isTrue(); // Wait for completion
+        
+        // Verify all results were added
+        assertThat(results.getAllResults()).hasSize(threadCount * 10);
+        
+        // Verify specific results
+        for (int i = 0; i < threadCount; i++) {
+            for (int j = 0; j < 10; j++) {
+                String key = "Thread" + i + "-Result" + j;
+                assertThat(results.getResult(key)).isEqualTo(j);
+            }
+        }
+    }
+    
+    @Test 
+    public void testIPVersionContext_IntegrationDuringParallelExecution() throws Exception {
+        System.setProperty("rdap.parallel.ipversions", "true");
+        
+        // Mock DNS resolver to ensure addresses are available
+        // Since we can't easily mock static methods, we'll use a simpler test approach
+        AtomicInteger ipv4CallCount = new AtomicInteger(0);
+        AtomicInteger ipv6CallCount = new AtomicInteger(0);
+        
+        // Create a validator that checks the IP version context
+        ValidatorWorkflow contextAwareValidator = new ValidatorWorkflow() {
+            public int validate() {
+                IPVersionContext context = IPVersionContext.current();
+                if (context == null) {
+                    return -1; // No context
+                }
+                
+                // Count calls by IP version to verify parallel execution
+                if (context.getProtocol() == NetworkProtocol.IPv4) {
+                    ipv4CallCount.incrementAndGet();
+                    // Verify system properties are set correctly for IPv4
+                    String preferIPv4 = System.getProperty("java.net.preferIPv4Addresses");
+                    String preferIPv6 = System.getProperty("java.net.preferIPv6Addresses");
+                    if (!"true".equals(preferIPv4) || !"false".equals(preferIPv6)) {
+                        return -2; // IPv4 properties not set correctly
+                    }
+                } else if (context.getProtocol() == NetworkProtocol.IPv6) {
+                    ipv6CallCount.incrementAndGet();
+                    // Verify system properties are set correctly for IPv6
+                    String preferIPv4 = System.getProperty("java.net.preferIPv4Addresses");
+                    String preferIPv6 = System.getProperty("java.net.preferIPv6Addresses");
+                    if (!"false".equals(preferIPv4) || !"true".equals(preferIPv6)) {
+                        return -3; // IPv6 properties not set correctly
+                    }
+                }
+                
+                return 0; // Success
+            }
+            
+            public String getResultsPath() {
+                return "/tmp/test-results";
+            }
+        };
+        
+        // Test with a simple hostname that we know exists
+        URI testUri = new URI("https://google.com");
+        BiConsumer<String, String> progressCallback = (ip, accept) -> {};
+        
+        NetworkValidationCoordinator.IPVersionValidationResults results = 
+            NetworkValidationCoordinator.executeIPVersionValidations(
+                contextAwareValidator, testUri, true, true, progressCallback);
+        
+        assertThat(results).isNotNull();
+        
+        // The validation should have been called, but actual results depend on DNS availability
+        // We'll check that the structure works correctly rather than specific validation outcomes
+        assertThat(results.getAllResults()).isNotEmpty();
+    }
+    
+    @Test
+    public void testParallelExecution_SystemPropertyCleanup() throws Exception {
+        System.setProperty("rdap.parallel.ipversions", "true");
+        
+        // Store original system properties
+        String originalPreferIPv4 = System.getProperty("java.net.preferIPv4Addresses");
+        String originalPreferIPv6 = System.getProperty("java.net.preferIPv6Addresses");
+        
+        ValidatorWorkflow mockValidator = mock(ValidatorWorkflow.class);
+        when(mockValidator.validate()).thenReturn(0);
+        
+        URI testUri = new URI("https://example.com");
+        BiConsumer<String, String> progressCallback = (ip, accept) -> {};
+        
+        NetworkValidationCoordinator.IPVersionValidationResults results = 
+            NetworkValidationCoordinator.executeIPVersionValidations(
+                mockValidator, testUri, true, true, progressCallback);
+        
+        // After execution completes, system properties should be cleaned up
+        // (Each IPVersionContext should restore properties when deactivated)
+        
+        // Give a moment for async cleanup to complete
+        Thread.sleep(100);
+        
+        // Properties should either be restored or in a clean state
+        String currentPreferIPv4 = System.getProperty("java.net.preferIPv4Addresses");
+        String currentPreferIPv6 = System.getProperty("java.net.preferIPv6Addresses");
+        
+        // The exact values depend on the cleanup order, but they shouldn't be stuck 
+        // in an inconsistent state like both true or both false
+        assertThat(currentPreferIPv4).isNotNull();
+        assertThat(currentPreferIPv6).isNotNull();
     }
 }


### PR DESCRIPTION
## Required Information

### PR Description (Include comprehensive description)

The tool should accept a new command line parameter called --dns-resolver that takes the IP address, either IPv4 or IPv6, of a DNS resolver. This DNS resolver is to be used by all DNS lookups in the tool.

#### Summary of changes:

#### Problem/feature addressed:
The tool was always stuck using the system's default nameservers and there was no way to change those on the command-line.

#### Relevant screenshots/diagrams:

#### Links to relevant issues/tasks:
https://icann-jira.atlassian.net/browse/RCT-356

### Branch Name
feat/RCT-396-ChangeDNSResolver

- [x] Does the branch name follow the Branch Naming Convention?

#### If not, explain why:

### Code Changes

- [x] Are code changes adhering to coding standards and practices?

#### If not, explain why:

### Commit Messages

- [x] Do commit messages follow [Conventional Commits guidelines](https://wecann.icann.org/docs/DOC-40501)?
- [x] Are they clear, concise, and informative using imperative language?

#### If not, explain why:

### Tests and Test Coverage

- [x] Are changes covered by appropriate tests?
- [x] Were unit tests, integration tests, and end-to-end tests run?
- [x] Was the test coverage maintained or improved? Please include before/after results.

#### If not, explain why:

### Bug Fixes and Tests

- [ ] For bug fixes, are there:
    - [ ] Tests that reproduce the bug before the changes?
    - [ ] Tests that demonstrate the bug is resolved after the changes?

#### If not, explain why:

### Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Documentation

- [ ] Are there updates to documentation that need to be made?
- [ ] Are they included or linked in the PR description?

#### If not, explain why:

### PR Size

- [ ] Is the PR small and focused on one logical change?

#### If not, explain why:
I also added the `-Drdap.parallel.ipversions=true` so that the tool runs v4/v6 in parallel, sometimes cutting the total time the tool takes in half.
---