### PR TITLE
bug/RCT-365-DNSArgumentNotHandlingErrors

### DIFF
--- a/validator/src/main/java/org/icann/rdapconformance/validator/CommonUtils.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/CommonUtils.java
@@ -70,8 +70,9 @@ public class CommonUtils {
     public static final String SEP = "://";
     public static final String LOCALHOST = "localhost";
     public static final String LOCAL_IPv4 = "127.0.0.1";
-
     public static final String LOCAL_IPv6 = "0000:0000:0000:0000:0000:0000:0000:0001";
+    public static final String LOCAL_IPv6_COMPRESSED = "::1";
+    public static final String ICANN_ORG_FQDN = "icann.org.";
     public static final String GET = "GET";
     public static final String HEAD = "HEAD";
     public static final String SEMI_COLON = ";";
@@ -97,6 +98,10 @@ public class CommonUtils {
     public static final int HTTP_NOT_FOUND = 404;
     public static final int HTTP_TOO_MANY_REQUESTS = 429;
     public static final String HANDLE_PATTERN = "(\\w|_){1,80}-\\w{1,8}";
+
+    // IP Address validation patterns
+    public static final String IPV4_PATTERN = "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$";
+    public static final String IP_BRACKET_ZONE_PATTERN = "[\\[\\]%.*]";
 
     private static final org.slf4j.Logger logger = LoggerFactory.getLogger(CommonUtils.class);
 

--- a/validator/src/main/java/org/icann/rdapconformance/validator/DNSCacheResolver.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/DNSCacheResolver.java
@@ -161,8 +161,11 @@ public class DNSCacheResolver {
                 logger.debug("DNS Resolver initialized using system DNS settings with {}s timeout and {} retries.",
                            DNS_TIMEOUT_SECONDS, DNS_RETRIES);
             }
+        } catch (RuntimeException e) {
+            // Re-throw RuntimeException (from health check failure) as-is
+            throw e;
         } catch (Exception e) {
-            logger.error("Failed to initialize DNS resolver with server '{}': {}. The value must be a valid IPv4 or IPv6 address.",
+            logger.error("Failed to initialize DNS resolver with server '{}': {}",
                        customDnsServer, e.getMessage());
             throw new RuntimeException("Invalid DNS resolver configuration", e);
         }


### PR DESCRIPTION
## Required Information

### PR Description (Include comprehensive description)
The Tool was not correctly handling invalid IP addresses when passed on the command-line with the flag: `dns-resolver`

#### Summary of changes:
Fix the IP handling and the messaging

#### Problem/feature addressed:
See Above

#### Relevant screenshots/diagrams:

#### Links to relevant issues/tasks:
https://icann-jira.atlassian.net/browse/RCT-356

### Branch Name
bug/RCT-365-DNSArgumentNotHandlingErrors

- [x] Does the branch name follow the Branch Naming Convention?

#### If not, explain why:

### Code Changes

- [x] Are code changes adhering to coding standards and practices?

#### If not, explain why:

### Commit Messages

- [x] Do commit messages follow [Conventional Commits guidelines](https://wecann.icann.org/docs/DOC-40501)?
- [x] Are they clear, concise, and informative using imperative language?

#### If not, explain why:

### Tests and Test Coverage

- [x] Are changes covered by appropriate tests?
- [x] Were unit tests, integration tests, and end-to-end tests run?
- [x] Was the test coverage maintained or improved? Please include before/after results.

#### If not, explain why:

### Bug Fixes and Tests

- [x] For bug fixes, are there:
    - [x] Tests that reproduce the bug before the changes?
    - [x] Tests that demonstrate the bug is resolved after the changes?

#### If not, explain why:

### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Documentation

- [ ] Are there updates to documentation that need to be made?
- [ ] Are they included or linked in the PR description?

#### If not, explain why:
NA

### PR Size

- [x] Is the PR small and focused on one logical change?

#### If not, explain why:

---