### PR TITLE
feat: RCT-480-ignore-last-database-event

### DIFF
--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/DomainCaseFoldingValidationTest.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/DomainCaseFoldingValidationTest.java
@@ -313,4 +313,116 @@ public class DomainCaseFoldingValidationTest extends HttpTestingUtils implements
     
     assertThat(validator.doLaunch()).isTrue();
   }
+
+  @Test
+  public void testDoValidate_DifferentLastUpdateEvent_ShouldPass() throws Exception {
+    WireMockConfiguration wmConfig = wireMockConfig()
+            .dynamicHttpsPort()
+            .bindAddress(WIREMOCK_HOST);
+    prepareWiremock(wmConfig);
+
+    String originalResponse = "{\n"
+            + "  \"objectClassName\": \"domain\",\n"
+            + "  \"ldhName\": \"test.example\",\n"
+            + "  \"events\": [\n"
+            + "    {\n"
+            + "      \"eventAction\": \"registration\",\n"
+            + "      \"eventDate\": \"2020-01-01T00:00:00Z\"\n"
+            + "    },\n"
+            + "    {\n"
+            + "      \"eventAction\": \"last update of RDAP database\",\n"
+            + "      \"eventDate\": \"2025-01-01T00:00:00Z\"\n"
+            + "    }\n"
+            + "  ]\n"
+            + "}";
+
+    String caseFoldedResponse = "{\n"
+            + "  \"objectClassName\": \"domain\",\n"
+            + "  \"ldhName\": \"test.example\",\n"
+            + "  \"events\": [\n"
+            + "    {\n"
+            + "      \"eventAction\": \"registration\",\n"
+            + "      \"eventDate\": \"2020-01-01T00:00:00Z\"\n"
+            + "    },\n"
+            + "    {\n"
+            + "      \"eventAction\": \"last update of RDAP database\",\n"
+            + "      \"eventDate\": \"2025-06-15T12:30:00Z\"\n"
+            + "    }\n"
+            + "  ]\n"
+            + "}";
+
+    givenUri("http");
+    doReturn(config.getUri()).when(httpsResponse).uri();
+    doReturn(200).when(httpsResponse).statusCode();
+    doReturn(originalResponse).when(httpsResponse).body();
+
+    // Case-folded URL returns same content except different "last update of RDAP database" date
+    String caseFoldedPath = "/domain/tEsT.ExAmPlE";
+    stubFor(get(urlEqualTo(caseFoldedPath))
+            .withScheme("http")
+            .willReturn(aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/rdap+json")
+                    .withBody(caseFoldedResponse)));
+
+    // Should PASS — the only difference is the "last update of RDAP database" event which must be ignored
+    validateOk(results);
+  }
+
+  @Test
+  public void testDoValidate_DifferentNonLastUpdateEvent_ShouldFail() throws Exception {
+    WireMockConfiguration wmConfig = wireMockConfig()
+            .dynamicHttpsPort()
+            .bindAddress(WIREMOCK_HOST);
+    prepareWiremock(wmConfig);
+
+    String originalResponse = "{\n"
+            + "  \"objectClassName\": \"domain\",\n"
+            + "  \"ldhName\": \"test.example\",\n"
+            + "  \"events\": [\n"
+            + "    {\n"
+            + "      \"eventAction\": \"registration\",\n"
+            + "      \"eventDate\": \"2020-01-01T00:00:00Z\"\n"
+            + "    },\n"
+            + "    {\n"
+            + "      \"eventAction\": \"last update of RDAP database\",\n"
+            + "      \"eventDate\": \"2025-01-01T00:00:00Z\"\n"
+            + "    }\n"
+            + "  ]\n"
+            + "}";
+
+    String caseFoldedResponse = "{\n"
+            + "  \"objectClassName\": \"domain\",\n"
+            + "  \"ldhName\": \"test.example\",\n"
+            + "  \"events\": [\n"
+            + "    {\n"
+            + "      \"eventAction\": \"registration\",\n"
+            + "      \"eventDate\": \"2022-05-05T00:00:00Z\"\n"
+            + "    },\n"
+            + "    {\n"
+            + "      \"eventAction\": \"last update of RDAP database\",\n"
+            + "      \"eventDate\": \"2025-01-01T00:00:00Z\"\n"
+            + "    }\n"
+            + "  ]\n"
+            + "}";
+
+    givenUri("http");
+    doReturn(config.getUri()).when(httpsResponse).uri();
+    doReturn(200).when(httpsResponse).statusCode();
+    doReturn(originalResponse).when(httpsResponse).body();
+
+    String caseFoldedPath = "/domain/tEsT.ExAmPlE";
+    stubFor(get(urlEqualTo(caseFoldedPath))
+            .withScheme("http")
+            .willReturn(aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/rdap+json")
+                    .withBody(caseFoldedResponse)));
+
+    // Should FAIL — the "registration" event date differs, which is NOT ignored
+    validateNotOk(results,
+            -10403, "http://127.0.0.1:8080/domain/tEsT.ExAmPlE",
+            "RDAP responses do not match when handling domain label case folding.");
+  }
+
 }

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/DomainCaseFoldingValidationTest.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/DomainCaseFoldingValidationTest.java
@@ -418,10 +418,11 @@ public class DomainCaseFoldingValidationTest extends HttpTestingUtils implements
                     .withStatus(200)
                     .withHeader("Content-Type", "application/rdap+json")
                     .withBody(caseFoldedResponse)));
+    String expectedUrl = config.getUri().resolve(caseFoldedPath).toString();
 
     // Should FAIL — the "registration" event date differs, which is NOT ignored
     validateNotOk(results,
-            -10403, "http://127.0.0.1:8080/domain/tEsT.ExAmPlE",
+            -10403, expectedUrl,
             "RDAP responses do not match when handling domain label case folding.");
   }
 


### PR DESCRIPTION
## Required Information

### PR Description (Include comprehensive description)

#### Summary of changes:
 add tests to validate handling of last update events in RDAP responses
#### Problem/feature addressed:
The test for the mixed case comparison needs to ignore the last RDAP update database event.

This impacts validation test -10403
#### Relevant screenshots/diagrams:

#### Links to relevant issues/tasks:
https://icann-jira.atlassian.net/browse/RCT-480
### Branch Name

- [x] Does the branch name follow the Branch Naming Convention?

#### If not, explain why:

### Code Changes

- [x] Are code changes adhering to coding standards and practices?

#### If not, explain why:

### Commit Messages

- [ ] Do commit messages follow [Conventional Commits guidelines](https://wecann.icann.org/docs/DOC-40501)?
- [x] Are they clear, concise, and informative using imperative language?

#### If not, explain why:

### Tests and Test Coverage

- [x] Are changes covered by appropriate tests?
- [ ] Were unit tests, integration tests, and end-to-end tests run?
- [ ] Was the test coverage maintained or improved? Please include before/after results.

#### If not, explain why:

### Bug Fixes and Tests

- [ ] For bug fixes, are there:
    - [ ] Tests that reproduce the bug before the changes?
    - [ ] Tests that demonstrate the bug is resolved after the changes?

#### If not, explain why:

### Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Documentation

- [ ] Are there updates to documentation that need to be made?
- [x] Are they included or linked in the PR description?

#### If not, explain why:

### PR Size

- [x] Is the PR small and focused on one logical change?

#### If not, explain why:

---