### PR TITLE
bug: RCT-477 Add IDN-aware URI conversion and validation for RDAP handling

### DIFF
--- a/tool/src/main/java/org/icann/rdapconformance/tool/Main.java
+++ b/tool/src/main/java/org/icann/rdapconformance/tool/Main.java
@@ -5,6 +5,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
+import java.net.URI;
+
 
 public class Main {
   private static final Logger logger = LoggerFactory.getLogger(Main.class);
@@ -12,6 +14,7 @@ public class Main {
   public static void main(String[] args) {
     RdapConformanceTool tool = new RdapConformanceTool();
     CommandLine commandLine = new CommandLine(tool);
+    commandLine.registerConverter(URI.class, new RdapConformanceTool.IdnAwareUriConverter());
     
     String errorMessage = UserInputValidator.parseOptions(args, tool, commandLine);
     

--- a/tool/src/main/java/org/icann/rdapconformance/tool/RdapConformanceTool.java
+++ b/tool/src/main/java/org/icann/rdapconformance/tool/RdapConformanceTool.java
@@ -1283,8 +1283,48 @@ public void setShowProgress(boolean showProgress) {
 
     private URI normalizeIdnUri(String input) throws java.net.URISyntaxException {
       // Pre-encode non-ASCII characters so java.net.URI can parse the structure
+      // BUT convert the host part to punycode first (URI doesn't accept percent-encoded hosts)
+
+      int schemeEnd = input.indexOf("://");
+      if (schemeEnd < 0) {
+        throw new java.net.URISyntaxException(input, "Missing scheme");
+      }
+
+      String scheme = input.substring(0, schemeEnd);
+      String rest = input.substring(schemeEnd + 3);
+
+      // Find where host ends (first / or end of string)
+      int hostEnd = rest.indexOf('/');
+      String hostPort = hostEnd >= 0 ? rest.substring(0, hostEnd) : rest;
+      String afterHost = hostEnd >= 0 ? rest.substring(hostEnd) : "";
+
+      // Convert host to punycode (handles Unicode hosts like whois.nic.дети)
+      // Skip IPv6 literals
+      String normalizedHostPort;
+      if (hostPort.startsWith("[")) {
+        normalizedHostPort = hostPort; // IPv6 — leave as-is
+      } else {
+        // Separate host from port
+        int lastColon = hostPort.lastIndexOf(':');
+        String portSuffix = "";
+        String hostOnly = hostPort;
+        if (lastColon >= 0) {
+          String maybPort = hostPort.substring(lastColon + 1);
+          try {
+            Integer.parseInt(maybPort);
+            portSuffix = hostPort.substring(lastColon);
+            hostOnly = hostPort.substring(0, lastColon);
+          } catch (NumberFormatException e) {
+            // Not a port
+          }
+        }
+        normalizedHostPort = toASCII(hostOnly) + portSuffix;
+      }
+
+      // Now percent-encode non-ASCII in the remaining part (path/query/fragment)
       StringBuilder encoded = new StringBuilder();
-      for (char c : input.toCharArray()) {
+      encoded.append(scheme).append("://").append(normalizedHostPort);
+      for (char c : afterHost.toCharArray()) {
         if (c > 0x7F) {
           for (byte b : String.valueOf(c).getBytes(UTF_8)) {
             encoded.append(String.format("%%%02X", b & 0xFF));
@@ -1294,22 +1334,8 @@ public void setShowProgress(boolean showProgress) {
         }
       }
 
-      // Now URI can parse the structure correctly (scheme, host, port, path, query, fragment)
+      // Parse the now-valid URI
       URI parsed = new URI(encoded.toString());
-
-      String host = parsed.getHost();
-      if (host == null) {
-        throw new java.net.URISyntaxException(input, "No host found");
-      }
-
-      // Decode percent-encoded host back to Unicode, then convert to punycode
-      // Skip IDN conversion for IPv6 literals (URI.getHost() strips brackets but keeps colons)
-      String normalizedHost = decode(host, UTF_8);
-      if (!normalizedHost.contains(":")) {
-        // Regular hostname — apply IDN conversion
-        normalizedHost = toASCII(normalizedHost);
-      }
-      // else: IPv6 address — pass through as-is, URI constructor re-adds brackets
 
       // Convert IDN domain names in the RDAP path to A-label (punycode)
       String path = parsed.getRawPath();
@@ -1317,7 +1343,7 @@ public void setShowProgress(boolean showProgress) {
         path = convertIdnInPath(path);
       }
 
-      return new URI(parsed.getScheme(), null, normalizedHost, parsed.getPort(),
+      return new URI(parsed.getScheme(), null, parsed.getHost(), parsed.getPort(),
               path, parsed.getRawQuery(), parsed.getRawFragment());
     }
 

--- a/tool/src/main/java/org/icann/rdapconformance/tool/RdapConformanceTool.java
+++ b/tool/src/main/java/org/icann/rdapconformance/tool/RdapConformanceTool.java
@@ -6,7 +6,9 @@ import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.joran.JoranConfigurator;
 
 import java.io.File;
+import java.net.IDN;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.security.Security;
 import java.util.List;
 import java.util.Map;
@@ -20,6 +22,7 @@ import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidator;
 import org.slf4j.LoggerFactory;
 import org.icann.rdapconformance.tool.progress.ProgressTracker;
 import org.icann.rdapconformance.tool.progress.ProgressPhase;
+import picocli.CommandLine;
 import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -1261,5 +1264,89 @@ public void setShowProgress(boolean showProgress) {
    */
   QueryContext getQueryContext() {
     return this.queryContext;
+  }
+
+  /** * Picocli type converter that handles IDN/Unicode URIs by normalizing them * before creating a java.net.URI. Supports both raw Unicode (nic.дети)  * and percent-encoded forms. */
+  static class IdnAwareUriConverter implements CommandLine.ITypeConverter<URI> {
+    @Override
+    public URI convert(String value) throws Exception {
+      // Always normalize IDN domains in the path, even if URI.create succeeds
+      // (e.g., percent-encoded Unicode like nic.%D0%B4%D0%B5%D1%82%D0%B8)
+      return normalizeIdnUri(value);
+    }
+
+    private URI normalizeIdnUri(String input) throws java.net.URISyntaxException {
+      int schemeEnd = input.indexOf("://");
+      if (schemeEnd < 0) {
+        throw new java.net.URISyntaxException(input, "Missing scheme");
+      }
+
+      String scheme = input.substring(0, schemeEnd);
+      String rest = input.substring(schemeEnd + 3);
+
+      int pathStart = rest.indexOf('/');
+      String hostPort = pathStart >= 0 ? rest.substring(0, pathStart) : rest;
+      String path = pathStart >= 0 ? rest.substring(pathStart) : "/";
+
+      String query = null;
+      int queryStart = path.indexOf('?');
+      if (queryStart >= 0) {
+        query = path.substring(queryStart + 1);
+        path = path.substring(0, queryStart);
+      }
+
+      String host = hostPort;
+      int port = -1;
+      int colonIdx = hostPort.lastIndexOf(':');
+      if (colonIdx >= 0) {
+        try {
+          port = Integer.parseInt(hostPort.substring(colonIdx + 1));
+          host = hostPort.substring(0, colonIdx);
+        } catch (NumberFormatException nfe) {
+          // Not a port
+        }
+      }
+
+      // Convert IDN host to ASCII (punycode)
+      host = java.net.IDN.toASCII(host);
+
+      // Convert IDN domain names in the RDAP path to A-label (punycode)
+      // e.g., /rdap/domain/nic.дети -> /rdap/domain/nic.xn--d1acj3b
+      path = convertIdnInPath(path);
+
+      return new URI(scheme, null, host, port, path, query, null);
+    }
+
+    /**
+     * Converts IDN domain names found in RDAP path segments to their A-label form.
+     * Handles paths like /rdap/domain/{domainName} and /rdap/nameserver/{nsName}
+     * where the domain/nameserver name may contain Unicode characters.
+     * Also handles percent-encoded Unicode by decoding first, then converting.
+     */
+    static String convertIdnInPath(String path) {
+      // Decode any percent-encoded characters first
+      String decodedPath;
+      try {
+        decodedPath = java.net.URLDecoder.decode(path, java.nio.charset.StandardCharsets.UTF_8);
+      } catch (Exception e) {
+        decodedPath = path;
+      }
+
+      // Match RDAP path patterns: /domain/{name} or /nameserver/{name}
+      // The domain name is the last segment after /domain/ or /nameserver/
+      String[] rdapPrefixes = {"/domain/", "/nameserver/"};
+      for (String prefix : rdapPrefixes) {
+        int idx = decodedPath.toLowerCase().lastIndexOf(prefix);
+        if (idx >= 0) {
+          String before = decodedPath.substring(0, idx + prefix.length());
+          String domainName = decodedPath.substring(idx + prefix.length());
+          // Convert each label to A-label
+          domainName = java.net.IDN.toASCII(domainName);
+          return before + domainName;
+        }
+      }
+
+      return decodedPath;
+    }
   }
 }

--- a/tool/src/main/java/org/icann/rdapconformance/tool/RdapConformanceTool.java
+++ b/tool/src/main/java/org/icann/rdapconformance/tool/RdapConformanceTool.java
@@ -6,9 +6,7 @@ import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.joran.JoranConfigurator;
 
 import java.io.File;
-import java.net.IDN;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.security.Security;
 import java.util.List;
 import java.util.Map;
@@ -45,6 +43,9 @@ import org.icann.rdapconformance.validator.workflow.rdap.RDAPDatasetServiceImpl;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import static java.net.IDN.toASCII;
+import static java.net.URLDecoder.decode;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.icann.rdapconformance.validator.CommonUtils.*;
 
 
@@ -1266,7 +1267,12 @@ public void setShowProgress(boolean showProgress) {
     return this.queryContext;
   }
 
-  /** * Picocli type converter that handles IDN/Unicode URIs by normalizing them * before creating a java.net.URI. Supports both raw Unicode (nic.дети)  * and percent-encoded forms. */
+  /**
+   * Picocli type converter that handles IDN/Unicode URIs by normalizing them
+   * before creating a java.net.URI.
+   * Supports both raw Unicode (nic.дети)
+   * and percent-encoded forms.
+  */
   static class IdnAwareUriConverter implements CommandLine.ITypeConverter<URI> {
     @Override
     public URI convert(String value) throws Exception {
@@ -1276,45 +1282,43 @@ public void setShowProgress(boolean showProgress) {
     }
 
     private URI normalizeIdnUri(String input) throws java.net.URISyntaxException {
-      int schemeEnd = input.indexOf("://");
-      if (schemeEnd < 0) {
-        throw new java.net.URISyntaxException(input, "Missing scheme");
-      }
-
-      String scheme = input.substring(0, schemeEnd);
-      String rest = input.substring(schemeEnd + 3);
-
-      int pathStart = rest.indexOf('/');
-      String hostPort = pathStart >= 0 ? rest.substring(0, pathStart) : rest;
-      String path = pathStart >= 0 ? rest.substring(pathStart) : "/";
-
-      String query = null;
-      int queryStart = path.indexOf('?');
-      if (queryStart >= 0) {
-        query = path.substring(queryStart + 1);
-        path = path.substring(0, queryStart);
-      }
-
-      String host = hostPort;
-      int port = -1;
-      int colonIdx = hostPort.lastIndexOf(':');
-      if (colonIdx >= 0) {
-        try {
-          port = Integer.parseInt(hostPort.substring(colonIdx + 1));
-          host = hostPort.substring(0, colonIdx);
-        } catch (NumberFormatException nfe) {
-          // Not a port
+      // Pre-encode non-ASCII characters so java.net.URI can parse the structure
+      StringBuilder encoded = new StringBuilder();
+      for (char c : input.toCharArray()) {
+        if (c > 0x7F) {
+          for (byte b : String.valueOf(c).getBytes(UTF_8)) {
+            encoded.append(String.format("%%%02X", b & 0xFF));
+          }
+        } else {
+          encoded.append(c);
         }
       }
 
-      // Convert IDN host to ASCII (punycode)
-      host = java.net.IDN.toASCII(host);
+      // Now URI can parse the structure correctly (scheme, host, port, path, query, fragment)
+      URI parsed = new URI(encoded.toString());
+
+      String host = parsed.getHost();
+      if (host == null) {
+        throw new java.net.URISyntaxException(input, "No host found");
+      }
+
+      // Decode percent-encoded host back to Unicode, then convert to punycode
+      // Skip IDN conversion for IPv6 literals (URI.getHost() strips brackets but keeps colons)
+      String normalizedHost = decode(host, UTF_8);
+      if (!normalizedHost.contains(":")) {
+        // Regular hostname — apply IDN conversion
+        normalizedHost = toASCII(normalizedHost);
+      }
+      // else: IPv6 address — pass through as-is, URI constructor re-adds brackets
 
       // Convert IDN domain names in the RDAP path to A-label (punycode)
-      // e.g., /rdap/domain/nic.дети -> /rdap/domain/nic.xn--d1acj3b
-      path = convertIdnInPath(path);
+      String path = parsed.getRawPath();
+      if (path != null) {
+        path = convertIdnInPath(path);
+      }
 
-      return new URI(scheme, null, host, port, path, query, null);
+      return new URI(parsed.getScheme(), null, normalizedHost, parsed.getPort(),
+              path, parsed.getRawQuery(), parsed.getRawFragment());
     }
 
     /**
@@ -1327,7 +1331,7 @@ public void setShowProgress(boolean showProgress) {
       // Decode any percent-encoded characters first
       String decodedPath;
       try {
-        decodedPath = java.net.URLDecoder.decode(path, java.nio.charset.StandardCharsets.UTF_8);
+        decodedPath = decode(path, UTF_8);
       } catch (Exception e) {
         decodedPath = path;
       }
@@ -1341,7 +1345,7 @@ public void setShowProgress(boolean showProgress) {
           String before = decodedPath.substring(0, idx + prefix.length());
           String domainName = decodedPath.substring(idx + prefix.length());
           // Convert each label to A-label
-          domainName = java.net.IDN.toASCII(domainName);
+          domainName = toASCII(domainName);
           return before + domainName;
         }
       }

--- a/tool/src/main/java/org/icann/rdapconformance/tool/RdapWebValidator.java
+++ b/tool/src/main/java/org/icann/rdapconformance/tool/RdapWebValidator.java
@@ -389,29 +389,23 @@ public class RdapWebValidator implements AutoCloseable {
      * @return a valid URI object
      * @throws IllegalArgumentException if the URI is invalid or has no scheme
      */
-    private static URI validateAndCreateURI(String uriString) {
+    static URI validateAndCreateURI(String uriString) {
         if (uriString == null || uriString.trim().isEmpty()) {
             throw new IllegalArgumentException("URI cannot be null or empty");
         }
-
         try {
-            URI uri = URI.create(uriString);
+            URI uri = new RdapConformanceTool.IdnAwareUriConverter().convert(uriString);
 
-            // Validate that the URI has a scheme (protocol)
             if (uri.getScheme() == null || uri.getScheme().trim().isEmpty()) {
                 throw new IllegalArgumentException("URI must have a valid scheme (e.g., https://): " + uriString);
             }
-
-            // Validate that it's an HTTP or HTTPS scheme for RDAP
             if (!uri.getScheme().equalsIgnoreCase("http") && !uri.getScheme().equalsIgnoreCase("https")) {
                 throw new IllegalArgumentException("URI must use HTTP or HTTPS scheme for RDAP: " + uriString);
             }
-
             return uri;
         } catch (IllegalArgumentException e) {
-            if (e.getMessage().contains("URI must")) {
-                throw e; // Re-throw our validation errors
-            }
+            throw e;
+        } catch (Exception e) {
             throw new IllegalArgumentException("Invalid URI format: " + uriString, e);
         }
     }

--- a/tool/src/main/java/org/icann/rdapconformance/tool/RdapWebValidator.java
+++ b/tool/src/main/java/org/icann/rdapconformance/tool/RdapWebValidator.java
@@ -383,11 +383,26 @@ public class RdapWebValidator implements AutoCloseable {
     }
 
     /**
-     * Validates and creates a URI from a string, throwing IllegalArgumentException for invalid URIs.
+     * Validates and creates a URI from a string, with IDN (Internationalized Domain Name) support.
      *
-     * @param uriString the URI string to validate
-     * @return a valid URI object
-     * @throws IllegalArgumentException if the URI is invalid or has no scheme
+     * <p>This method normalizes IDN domain names in both the host and RDAP path segments
+     * (e.g., {@code /domain/} and {@code /nameserver/}) to their A-label (punycode) form
+     * using {@link RdapConformanceTool.IdnAwareUriConverter}. It supports:</p>
+     * <ul>
+     *   <li>Raw Unicode domain names (e.g., {@code nic.дети})</li>
+     *   <li>Percent-encoded Unicode (e.g., {@code nic.%D0%B4%D0%B5%D1%82%D0%B8})</li>
+     *   <li>Already-punycode domains (e.g., {@code nic.xn--d1acj3b})</li>
+     *   <li>IPv6 literal hosts (e.g., {@code https://[2001:db8::1]/...})</li>
+     * </ul>
+     *
+     * <p>The URI must use an HTTP or HTTPS scheme. Inputs without a scheme produce
+     * an {@code IllegalArgumentException} with the message
+     * {@code "URI must have a valid scheme (e.g., https://): ..."}.</p>
+     *
+     * @param uriString the URI string to validate and normalize
+     * @return a valid, IDN-normalized URI object
+     * @throws IllegalArgumentException if the URI is null, empty, has no scheme,
+     *         uses a non-HTTP(S) scheme, or is otherwise malformed
      */
     static URI validateAndCreateURI(String uriString) {
         if (uriString == null || uriString.trim().isEmpty()) {
@@ -405,6 +420,12 @@ public class RdapWebValidator implements AutoCloseable {
             return uri;
         } catch (IllegalArgumentException e) {
             throw e;
+        } catch (java.net.URISyntaxException e) {
+            // Preserve specific error message for missing scheme
+            if (e.getReason() != null && e.getReason().contains("No host found")) {
+                throw new IllegalArgumentException("URI must have a valid scheme (e.g., https://): " + uriString, e);
+            }
+            throw new IllegalArgumentException("Invalid URI format: " + uriString, e);
         } catch (Exception e) {
             throw new IllegalArgumentException("Invalid URI format: " + uriString, e);
         }

--- a/tool/src/test/java/org/icann/rdapconformance/tool/IdnAwareUriConverterTest.java
+++ b/tool/src/test/java/org/icann/rdapconformance/tool/IdnAwareUriConverterTest.java
@@ -1,0 +1,117 @@
+package org.icann.rdapconformance.tool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.net.URI;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import picocli.CommandLine;
+
+public class IdnAwareUriConverterTest {
+
+    private final RdapConformanceTool.IdnAwareUriConverter converter =
+            new RdapConformanceTool.IdnAwareUriConverter();
+
+    // --- convertIdnInPath tests ---
+
+    @DataProvider(name = "idnPathConversions")
+    public Object[][] idnPathConversions() {
+        return new Object[][] {
+                // Unicode domain in path → punycode
+                { "/rdap/domain/nic.дети", "/rdap/domain/nic.xn--d1acj3b" },
+                // Percent-encoded Unicode → punycode
+                { "/rdap/domain/nic.%D0%B4%D0%B5%D1%82%D0%B8", "/rdap/domain/nic.xn--d1acj3b" },
+                // Already punycode → unchanged
+                { "/rdap/domain/nic.xn--d1acj3b", "/rdap/domain/nic.xn--d1acj3b" },
+                // ASCII domain → unchanged
+                { "/rdap/domain/example.com", "/rdap/domain/example.com" },
+                // Nameserver with IDN
+                { "/rdap/nameserver/ns1.дети", "/rdap/nameserver/ns1.xn--d1acj3b" },
+                // Non-domain path → unchanged
+                { "/rdap/help", "/rdap/help" },
+                // Unicode TLD only
+                { "/rdap/domain/test.münchen", "/rdap/domain/test.xn--mnchen-3ya" },
+        };
+    }
+
+    @Test(dataProvider = "idnPathConversions")
+    public void testConvertIdnInPath(String input, String expected) {
+        String result = RdapConformanceTool.IdnAwareUriConverter.convertIdnInPath(input);
+        assertThat(result).isEqualTo(expected);
+    }
+
+    // --- Full URI conversion tests ---
+
+    @DataProvider(name = "idnUriConversions")
+    public Object[][] idnUriConversions() {
+        return new Object[][] {
+                // Unicode domain in path
+                {
+                        "https://whois.nic.xn--d1acj3b/rdap/domain/nic.дети",
+                        "https://whois.nic.xn--d1acj3b/rdap/domain/nic.xn--d1acj3b"
+                },
+                // Percent-encoded Unicode
+                {
+                        "https://whois.nic.xn--d1acj3b/rdap/domain/nic.%D0%B4%D0%B5%D1%82%D0%B8",
+                        "https://whois.nic.xn--d1acj3b/rdap/domain/nic.xn--d1acj3b"
+                },
+                // Already ASCII — no change
+                {
+                        "https://rdap.example.com/rdap/domain/example.com",
+                        "https://rdap.example.com/rdap/domain/example.com"
+                },
+                // Unicode in host AND path
+                {
+                        "https://whois.nic.дети/rdap/domain/nic.дети",
+                        "https://whois.nic.xn--d1acj3b/rdap/domain/nic.xn--d1acj3b"
+                },
+        };
+    }
+
+    @Test(dataProvider = "idnUriConversions")
+    public void testConvertFullUri(String input, String expected) throws Exception {
+        URI result = converter.convert(input);
+        assertThat(result.toString()).isEqualTo(expected);
+    }
+
+    // --- Picocli integration test ---
+
+    @Test
+    public void testPicocliParsesIdnUri() {
+        RdapConformanceTool tool = new RdapConformanceTool();
+        CommandLine cmd = new CommandLine(tool);
+        cmd.registerConverter(URI.class, new RdapConformanceTool.IdnAwareUriConverter());
+
+        String[] args = {
+                "https://whois.nic.xn--d1acj3b/rdap/domain/nic.дети",
+                "--config=/tmp/test",
+                "--gtld-registrar"
+        };
+
+        assertThatCode(() -> cmd.parseArgs(args)).doesNotThrowAnyException();
+        assertThat(tool.getUri().toString())
+                .isEqualTo("https://whois.nic.xn--d1acj3b/rdap/domain/nic.xn--d1acj3b");
+    }
+
+    // --- Edge cases ---
+
+    @Test(expectedExceptions = Exception.class)
+    public void testMissingSchemeFails() throws Exception {
+        converter.convert("whois.nic.xn--d1acj3b/rdap/domain/nic.дети");
+    }
+
+    @Test
+    public void testUriWithPort() throws Exception {
+        URI result = converter.convert("https://example.com:8443/rdap/domain/nic.дети");
+        assertThat(result.getPort()).isEqualTo(8443);
+        assertThat(result.getPath()).isEqualTo("/rdap/domain/nic.xn--d1acj3b");
+    }
+
+    @Test
+    public void testUriWithQueryString() throws Exception {
+        URI result = converter.convert("https://example.com/rdap/domain/nic.дети?foo=bar");
+        assertThat(result.getPath()).isEqualTo("/rdap/domain/nic.xn--d1acj3b");
+        assertThat(result.getQuery()).isEqualTo("foo=bar");
+    }
+}

--- a/tool/src/test/java/org/icann/rdapconformance/tool/RdapWebValidatorTest.java
+++ b/tool/src/test/java/org/icann/rdapconformance/tool/RdapWebValidatorTest.java
@@ -1,5 +1,6 @@
 package org.icann.rdapconformance.tool;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.*;
 
 import java.io.IOException;
@@ -581,6 +582,15 @@ public class RdapWebValidatorTest {
             RDAPValidatorResults results = validator.validate();
             assertNotNull(results, "Validation should return results object");
         }
+    }
+
+    @Test
+    public void testValidateAndCreateURI_WithIdnDomain() {
+        // This tests that the web validator correctly handles IDN URIs
+        URI result = RdapWebValidator.validateAndCreateURI(
+                "https://whois.nic.xn--d1acj3b/rdap/domain/nic.дети");
+        assertThat(result.toString())
+                .isEqualTo("https://whois.nic.xn--d1acj3b/rdap/domain/nic.xn--d1acj3b");
     }
 
     /**


### PR DESCRIPTION
## Required Information

### PR Description (Include comprehensive description)

#### Summary of changes:
RDAP lookups with IDN (Internationalized Domain Name) query targets
were returning HTTP 404 because the Unicode domain name in the URI
path was being sent as-is or percent-encoded instead of being
converted to its A-label (punycode) form.

For example, querying:
  https://whois.nic.xn--d1acj3b/rdap/domain/nic.дети
was sent as /rdap/domain/nic.%D0%B4%D0%B5%D1%82%D0%B8 but the
server expects /rdap/domain/nic.xn--d1acj3b

Changes:
- Add IdnAwareUriConverter (ITypeConverter<URI>) to RdapConformanceTool
  that normalizes IDN domains in both the host and the RDAP path
  (/domain/ and /nameserver/ segments) using java.net.IDN.toASCII()
- Register the converter in Main.java for picocli CLI parsing
- Update RdapWebValidator.validateAndCreateURI() to use the same
  IDN normalization logic for the web API entry point
- Add IdnAwareUriConverterTest with parameterized tests covering:
  Unicode, percent-encoded, already-punycode, and ASCII inputs,
  plus edge cases (port, query string, missing scheme)
- Add testValidateAndCreateURI_WithIdnDomain to RdapWebValidatorTest

Both unencoded (nic.дети) and percent-encoded
(nic.%D0%B4%D0%B5%D1%82%D0%B8) URI forms are now correctly
converted to their A-label equivalent before the HTTP request.
#### Problem/feature addressed:
Looking up the following RDAP URLs with IDN query targets yields HTTP 404 when the domains are in fact there:

unencoded: [https://whois.nic.xn--d1acj3b/rdap/domain/nic.дети](https://whois.nic.xn--d1acj3b/rdap/domain/nic.%D0%B4%D0%B5%D1%82%D0%B8) 

url encoded: https://whois.nic.xn--d1acj3b/rdap/domain/nic.%D0%B4%D0%B5%D1%82%D0%B8

Both should work.
#### Relevant screenshots/diagrams:

#### Links to relevant issues/tasks:
https://icann-jira.atlassian.net/browse/RCT-477
### Branch Name

- [x] Does the branch name follow the Branch Naming Convention?

#### If not, explain why:

### Code Changes

- [x] Are code changes adhering to coding standards and practices?

#### If not, explain why:

### Commit Messages

- [ ] Do commit messages follow [Conventional Commits guidelines](https://wecann.icann.org/docs/DOC-40501)?
- [x] Are they clear, concise, and informative using imperative language?

#### If not, explain why:

### Tests and Test Coverage

- [x] Are changes covered by appropriate tests?
- [ ] Were unit tests, integration tests, and end-to-end tests run?
- [ ] Was the test coverage maintained or improved? Please include before/after results.

#### If not, explain why:

### Bug Fixes and Tests

- [ ] For bug fixes, are there:
    - [x] Tests that reproduce the bug before the changes?
    - [ ] Tests that demonstrate the bug is resolved after the changes?

#### If not, explain why:

### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Documentation

- [ ] Are there updates to documentation that need to be made?
- [x] Are they included or linked in the PR description?

#### If not, explain why:

### PR Size

- [x] Is the PR small and focused on one logical change?

#### If not, explain why:

---