### PR TITLE
bug/RCT-488-[REGRESSION] 13002 false postive

### DIFF
--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidator.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidator.java
@@ -85,6 +85,9 @@ public class RDAPValidator implements ValidatorWorkflow {
 
     @Override
     public int validate() {
+        // Reset stale HTTP context from previous rounds
+        queryContext.setCurrentHttpResponse(null);
+
         SchemaValidator validator = null;
         Map<RDAPQueryType, String> schemaMap = getDomainMap();
 

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
@@ -131,6 +131,8 @@ public class RDAPHttpQuery implements RDAPQuery {
         // without this we error out forever after a single failure
         this.isQuerySuccessful = true; // reset to the default state
         this.status = null; // same
+        this.httpResponse = null;
+        this.redirects = new ArrayList<>();
         // continue on
         this.makeRequest(this.config.getUri());
         this.validate();

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
@@ -136,6 +136,11 @@ public class RDAPHttpQuery implements RDAPQuery {
         // continue on
         this.makeRequest(this.config.getUri());
         this.validate();
+
+        if (this.httpResponse == null) {
+            this.isQuerySuccessful = false;
+        }
+
         return this.isQuerySuccessful();
     }
 

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidatorTest.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidatorTest.java
@@ -162,5 +162,51 @@ public void testValidate_DomainQueryForTestInvalidWithHttpOK_LogsInfo() throws I
     // The validator will use its QueryContext's processor instead of a singleton
 
     assertThat(validator.validate()).isEqualTo(ToolResult.SUCCESS.getCode());
-}
+    }
+
+    @Test
+    public void testValidate_TwoRoundsOnSameContext_SecondRoundDoesNotInheritFirstRoundHttpStatus() {
+        // Simulate the regression: first round succeeds with 200, second round fails
+        // (e.g., server rate-limits with 429). Without the fix, the second round's
+        // RDAPValidationResult.build(queryContext) would inherit the 200 status from round 1.
+
+        RDAPValidatorConfiguration config = mock(RDAPValidatorConfiguration.class);
+        RDAPQuery query = mock(RDAPQuery.class);
+        RDAPDatasetService datasetService = mock(RDAPDatasetService.class);
+
+        doReturn(URI.create("https://example.com/rdap/domain/test.example")).when(config).getUri();
+        doReturn(true).when(config).check();
+        doReturn(false).when(config).useRdapProfileFeb2019();
+        doReturn(false).when(config).useRdapProfileFeb2024();
+        doReturn(false).when(config).isAdditionalConformanceQueries();
+        doReturn(false).when(config).isNetworkEnabled();
+        doReturn(true).when(datasetService).download(anyBoolean());
+
+        // Round 1: query succeeds, raw response has HTTP 200
+        RDAPHttpRequest.SimpleHttpResponse round1Response = mock(RDAPHttpRequest.SimpleHttpResponse.class);
+        when(round1Response.statusCode()).thenReturn(HTTP_OK);
+        when(round1Response.body()).thenReturn("{\"objectClassName\":\"domain\"}");
+        when(round1Response.uri()).thenReturn(URI.create("https://example.com/rdap/domain/test.example"));
+
+        // Round 2: query fails (run() returns false), simulating a 429 or network error
+        // At this point getRawResponse() returns null — no new response was set
+        doReturn(false).when(query).run();
+        doReturn(null).when(query).getErrorStatus();   // null → ToolResult.SUCCESS path
+        doReturn(null).when(query).getRawResponse();
+
+        QueryContext queryContext = QueryContext.create(config, datasetService, query);
+        RDAPValidator validator = new RDAPValidator(queryContext);
+
+        // Round 1: manually prime currentHttpResponse as if round 1 had succeeded
+        queryContext.setCurrentHttpResponse(round1Response);
+
+        // Round 2: call validate() again on the same QueryContext
+        validator.validate();
+
+        // After the fix, currentHttpResponse must be null at the start of round 2,
+        // so no stale HTTP 200 leaks into error results produced in this round.
+        assertThat(queryContext.getCurrentHttpResponse())
+                .as("currentHttpResponse should be null after a failed round; stale response from round 1 must not persist")
+                .isNull();
+    }
 }


### PR DESCRIPTION
## Required Information

### PR Description (Include comprehensive description)

#### Summary of changes:
When running multiple validation rounds (IPv4/IPv6 × JSON/RDAP+JSON),
the same RDAPHttpQuery instance was reused without fully resetting its
state between calls to run(). Specifically, httpResponse and redirects
were never cleared, causing a previous round's response to leak into
the next round's validate() method if makeRequest() failed to update
httpResponse (e.g., due to a server-side rate limit returning 429).

This produced a spurious -13002 error ("The HTTP status code was
neither 200 nor 404.") with value "429" even when the target server
correctly returned 404, because validate() was reading a stale
httpResponse from a prior round.

A second related issue caused receivedHttpStatusCode in the -13002
result to show 404 (from the previous round's currentHttpResponse
stored in QueryContext) while value showed 429, making the error
appear contradictory and difficult to diagnose.

Changes:
- RDAPHttpQuery.run(): reset httpResponse to null and redirects to a
  new list at the start of each run, ensuring no state bleeds between
  successive calls on the same instance.
- RDAPValidator.validate(): reset queryContext.currentHttpResponse to
  null at the start of each validation round, so that any error built
  via RDAPValidationResult.builder().build(queryContext) does not
  inherit the HTTP status code from a previous round.
#### Problem/feature addressed:
When a server returns 404, we are getting -13002 (The HTTP status code was neither 200 nor 404.) It value says “429”, so maybe RDAPCT was getting 429s for other responses and got confused somehow.
#### Relevant screenshots/diagrams:

#### Links to relevant issues/tasks:
https://icann-jira.atlassian.net/browse/RCT-488
### Branch Name

- [x] Does the branch name follow the Branch Naming Convention?

#### If not, explain why:

### Code Changes

- [x] Are code changes adhering to coding standards and practices?

#### If not, explain why:

### Commit Messages

- [ ] Do commit messages follow [Conventional Commits guidelines](https://wecann.icann.org/docs/DOC-40501)?
- [x] Are they clear, concise, and informative using imperative language?

#### If not, explain why:

### Tests and Test Coverage

- [x] Are changes covered by appropriate tests?
- [ ] Were unit tests, integration tests, and end-to-end tests run?
- [ ] Was the test coverage maintained or improved? Please include before/after results.

#### If not, explain why:

### Bug Fixes and Tests

- [ ] For bug fixes, are there:
    - [x] Tests that reproduce the bug before the changes?
    - [ ] Tests that demonstrate the bug is resolved after the changes?

#### If not, explain why:

### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Documentation

- [ ] Are there updates to documentation that need to be made?
- [x] Are they included or linked in the PR description?

#### If not, explain why:

### PR Size

- [x] Is the PR small and focused on one logical change?

#### If not, explain why:

---