### PR TITLE
feat/RCT-484-Implement SSRF protection with configurable allowed hosts

### DIFF
--- a/tool/src/main/java/org/icann/rdapconformance/tool/RdapConformanceTool.java
+++ b/tool/src/main/java/org/icann/rdapconformance/tool/RdapConformanceTool.java
@@ -164,7 +164,8 @@ public class RdapConformanceTool implements RDAPValidatorConfiguration, Callable
   @Option(names = {"--ssrf-allowed-hosts"},
           description = "Hosts/IPs to allow through SSRF protection (for QA/testing environments). " +
                   "Can be specified multiple times.",
-          paramLabel = "HOST")
+          paramLabel = "HOST",
+          hidden = true)
   private List<String> ssrfAllowedHosts = new java.util.ArrayList<>();
 
   // Progress tracking

--- a/tool/src/main/java/org/icann/rdapconformance/tool/RdapConformanceTool.java
+++ b/tool/src/main/java/org/icann/rdapconformance/tool/RdapConformanceTool.java
@@ -161,6 +161,12 @@ public class RdapConformanceTool implements RDAPValidatorConfiguration, Callable
           description = "Custom DNS resolver IP address (e.g., 8.8.8.8 or 2001:4860:4860::8888)")
   private String customDnsResolver;
 
+  @Option(names = {"--ssrf-allowed-hosts"},
+          description = "Hosts/IPs to allow through SSRF protection (for QA/testing environments). " +
+                  "Can be specified multiple times.",
+          paramLabel = "HOST")
+  private List<String> ssrfAllowedHosts = new java.util.ArrayList<>();
+
   // Progress tracking
   private ProgressTracker progressTracker;
   private boolean showProgress = true; // Default to true for CLI usage
@@ -358,6 +364,11 @@ public void setShowProgress(boolean showProgress) {
 
   public String getCustomDnsResolver() {
       return this.customDnsResolver;
+  }
+
+  @Override
+  public List<String> getSsrfAllowedHosts() {
+    return ssrfAllowedHosts;
   }
 
   @Override

--- a/tool/src/main/java/org/icann/rdapconformance/tool/RdapWebValidator.java
+++ b/tool/src/main/java/org/icann/rdapconformance/tool/RdapWebValidator.java
@@ -210,7 +210,6 @@ public class RdapWebValidator implements AutoCloseable {
 
         // Create QueryContext - this is the central "world object" for validation
         this.queryContext = QueryContext.create(config, datasetService, query);
-        config.getSsrfAllowedHosts().forEach(queryContext::addSsrfAllowedHost);
 
         // Create the RDAP validator using our QueryContext
         this.rdapValidator = new RDAPValidator(queryContext);

--- a/tool/src/main/java/org/icann/rdapconformance/tool/RdapWebValidator.java
+++ b/tool/src/main/java/org/icann/rdapconformance/tool/RdapWebValidator.java
@@ -210,6 +210,7 @@ public class RdapWebValidator implements AutoCloseable {
 
         // Create QueryContext - this is the central "world object" for validation
         this.queryContext = QueryContext.create(config, datasetService, query);
+        config.getSsrfAllowedHosts().forEach(queryContext::addSsrfAllowedHost);
 
         // Create the RDAP validator using our QueryContext
         this.rdapValidator = new RDAPValidator(queryContext);

--- a/validator/src/main/java/org/icann/rdapconformance/validator/QueryContext.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/QueryContext.java
@@ -1,5 +1,6 @@
 package org.icann.rdapconformance.validator;
 
+import java.net.InetAddress;
 import java.net.http.HttpResponse;
 import java.util.Collections;
 import java.util.HashSet;
@@ -576,7 +577,21 @@ public class QueryContext {
     }
 
     public void addSsrfAllowedHost(String host) {
-        this.ssrfAllowedHosts.add(host.toLowerCase());
+        if (host == null || host.isBlank()) return;
+        String trimmed = host.trim();
+
+        // Try to parse as an IP address and store its canonical form.
+        // This normalizes IPv6 representations so that user-provided values like
+        // "::1", "0:0:0:0:0:0:0:1", "2620:0:2830:270:0:0:0:173", or
+        // "2620:0:2830:270::173" all resolve to the same canonical string
+        // that InetAddress.getHostAddress() will produce at comparison time.
+        try {
+            InetAddress addr = InetAddress.getByName(trimmed);
+            this.ssrfAllowedHosts.add(addr.getHostAddress());
+        } catch (java.net.UnknownHostException e) {
+            // Not a valid IP literal — treat it as a hostname, store lowercase
+            this.ssrfAllowedHosts.add(trimmed.toLowerCase());
+        }
     }
 
     public Set<String> getSsrfAllowedHosts() {

--- a/validator/src/main/java/org/icann/rdapconformance/validator/QueryContext.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/QueryContext.java
@@ -1,6 +1,9 @@
 package org.icann.rdapconformance.validator;
 
 import java.net.http.HttpResponse;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 
 import org.icann.rdapconformance.validator.configuration.RDAPValidatorConfiguration;
@@ -67,6 +70,9 @@ public class QueryContext {
     // Flag for enable testing
     private boolean ssrfProtectionEnabled = true;
 
+    // Set of allowed hosts for SSRF protection (can be configured for testing)
+    private Set<String> ssrfAllowedHosts = new HashSet<>();
+
     /**
      * Constructs a new QueryContext with the specified configuration and services.
      *
@@ -127,6 +133,8 @@ public class QueryContext {
         if (query instanceof org.icann.rdapconformance.validator.workflow.rdap.http.RDAPHttpQuery) {
             ((org.icann.rdapconformance.validator.workflow.rdap.http.RDAPHttpQuery) query).setQueryContext(this);
         }
+
+        config.getSsrfAllowedHosts().forEach(this::addSsrfAllowedHost);
     }
 
     /**
@@ -565,6 +573,14 @@ public class QueryContext {
 
     public boolean isSsrfProtectionEnabled() {
         return ssrfProtectionEnabled;
+    }
+
+    public void addSsrfAllowedHost(String host) {
+        this.ssrfAllowedHosts.add(host.toLowerCase());
+    }
+
+    public Set<String> getSsrfAllowedHosts() {
+        return Collections.unmodifiableSet(ssrfAllowedHosts);
     }
 
     @Override

--- a/validator/src/main/java/org/icann/rdapconformance/validator/configuration/RDAPValidatorConfiguration.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/configuration/RDAPValidatorConfiguration.java
@@ -3,6 +3,9 @@ package org.icann.rdapconformance.validator.configuration;
 import com.ibm.icu.text.IDNA;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.List;
+
 import org.icann.rdapconformance.validator.workflow.rdap.RDAPQueryType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,6 +53,15 @@ public interface RDAPValidatorConfiguration {
    */
   default String getDatasetDirectory() {
     return null;
+  }
+
+
+  /**
+   *
+   * @return
+   */
+  default List<String> getSsrfAllowedHosts() {
+    return Collections.emptyList();
   }
 
   /**

--- a/validator/src/main/java/org/icann/rdapconformance/validator/configuration/RDAPValidatorConfiguration.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/configuration/RDAPValidatorConfiguration.java
@@ -57,8 +57,38 @@ public interface RDAPValidatorConfiguration {
 
 
   /**
+   * Returns the list of hosts or IP addresses that are explicitly exempted from
+   * SSRF (Server-Side Request Forgery) protection checks.
    *
-   * @return
+   * <p>Entries in this list bypass the private/reserved IP address validation
+   * performed in both the initial connection check and redirect destination
+   * validation. This allows specific internal or test servers to be reached
+   * even when their resolved IP addresses fall within ranges that would
+   * otherwise be blocked (e.g., RFC 1918 private IPv4, ULA IPv6, loopback).</p>
+   *
+   * <p><strong>Accepted value formats:</strong></p>
+   * <ul>
+   *   <li><strong>Hostnames</strong> — matched case-insensitively against the
+   *       request URI host (e.g., {@code ts-wire-mock.icann.org})</li>
+   *   <li><strong>IPv4 literals</strong> — matched against the resolved remote
+   *       address (e.g., {@code 10.47.230.173})</li>
+   *   <li><strong>IPv6 literals</strong> — matched against the resolved remote
+   *       address in full expanded or compressed form
+   *       (e.g., {@code 2620:0:2830:270:0:0:0:173})</li>
+   * </ul>
+   *
+   * <p><strong>Matching behavior:</strong> An entry matches if it equals either
+   * the resolved IP address ({@code InetAddress.getHostAddress()}) or the
+   * lowercase hostname extracted from the request URI. No CIDR range matching
+   * or wildcard expansion is performed — values must be exact.</p>
+   *
+   * <p><strong>Cross-family note:</strong> Allowlisting a hostname permits
+   * connections on <em>both</em> IPv4 and IPv6 for that host. Allowlisting a
+   * specific IP literal permits only that exact address.</p>
+   *
+   * @return an unmodifiable list of hostname or IP literal strings to exempt
+   *         from SSRF validation; never {@code null}; empty by default
+   * @see org.icann.rdapconformance.validator.workflow.rdap.http.RDAPHttpRequest
    */
   default List<String> getSsrfAllowedHosts() {
     return Collections.emptyList();

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
@@ -424,38 +424,56 @@ public class RDAPHttpQuery implements RDAPQuery {
         String host = uri.getHost();
         if (host == null) return true;
 
-        // Block localhost hostnames
+        // Normalize host: if it's an IP literal (v4 or v6), resolve to canonical form
+        // so that allowlist comparison matches the same canonical form stored at insertion time.
+        // e.g., uri.getHost() on "[2620:0:2830:270::173]" yields "2620:0:2830:270::173"
+        // which must be normalized to "2620:0:2830:270:0:0:0:173" to match the stored entry.
+        String normalizedHost;
+        try {
+            InetAddress parsed = InetAddress.getByName(host);
+            normalizedHost = parsed.getHostAddress(); // canonical form
+        } catch (UnknownHostException e) {
+            normalizedHost = host.toLowerCase(); // treat as hostname, lowercase
+        }
+
+        // Block well-known localhost literals before DNS resolution
         if ("localhost".equalsIgnoreCase(host) ||
-                "127.0.0.1".equals(host) ||
-                "::1".equals(host) ||
-                "0.0.0.0".equals(host)) {
+                "127.0.0.1".equals(normalizedHost) ||
+                "0:0:0:0:0:0:0:1".equals(normalizedHost) || // ::1 normalized
+                "0.0.0.0".equals(normalizedHost)) {
             return true;
         }
 
-        // Resolve and check the IP address
+        InetAddress[] addresses;
         try {
-            InetAddress[] addresses = InetAddress.getAllByName(host);
-            for (InetAddress addr : addresses) {
-                String ip = addr.getHostAddress();
-
-                // Allowlist check - if any IP Host is in the allowlist, allows
-                if (queryContext.getSsrfAllowedHosts().contains(ip) ||
-                        queryContext.getSsrfAllowedHosts().contains(host.toLowerCase())) {
-                    return false; // explicitly allowed
-                }
-
-                if (addr.isLoopbackAddress() ||
-                        addr.isSiteLocalAddress() ||
-                        addr.isLinkLocalAddress() ||
-                        addr.isAnyLocalAddress() ||
-                        isIPv6UniqueLocalAddress(addr) ||
-                        "169.254.169.254".equals(ip)) {
-                    return true;
-                }
-            }
+            addresses = InetAddress.getAllByName(host);
         } catch (UnknownHostException e) {
             return true;
         }
+
+        // PASS 1: allowlist check — use normalizedHost so IPv6 literals match canonical stored form
+        if (queryContext.getSsrfAllowedHosts().contains(normalizedHost)) {
+            return false;
+        }
+        for (InetAddress addr : addresses) {
+            if (queryContext.getSsrfAllowedHosts().contains(addr.getHostAddress())) {
+                return false;
+            }
+        }
+
+        // PASS 2: block if any address is private/reserved
+        for (InetAddress addr : addresses) {
+            String ip = addr.getHostAddress();
+            if (addr.isLoopbackAddress() ||
+                    addr.isSiteLocalAddress() ||
+                    addr.isLinkLocalAddress() ||
+                    addr.isAnyLocalAddress() ||
+                    isIPv6UniqueLocalAddress(addr) ||
+                    "169.254.169.254".equals(ip)) {
+                return true;
+            }
+        }
+
         return false;
     }
 

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
@@ -436,20 +436,25 @@ public class RDAPHttpQuery implements RDAPQuery {
         try {
             InetAddress[] addresses = InetAddress.getAllByName(host);
             for (InetAddress addr : addresses) {
-                if (addr.isLoopbackAddress() ||      // 127.0.0.0/8, ::1
-                        addr.isSiteLocalAddress() ||     // 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
-                        addr.isLinkLocalAddress() ||     // 169.254.0.0/16, fe80::/10
-                        addr.isAnyLocalAddress() ||
-                        isIPv6UniqueLocalAddress(addr)) {      // 0.0.0.0, ::
-                    return true;
+                String ip = addr.getHostAddress();
+
+                // Allowlist check - if any IP Host is in the allowlist, allows
+                if (queryContext.getSsrfAllowedHosts().contains(ip) ||
+                        queryContext.getSsrfAllowedHosts().contains(host.toLowerCase())) {
+                    return false; // explicitly allowed
                 }
-                // Block cloud metadata endpoint
-                if ("169.254.169.254".equals(addr.getHostAddress())) {
+
+                if (addr.isLoopbackAddress() ||
+                        addr.isSiteLocalAddress() ||
+                        addr.isLinkLocalAddress() ||
+                        addr.isAnyLocalAddress() ||
+                        isIPv6UniqueLocalAddress(addr) ||
+                        "169.254.169.254".equals(ip)) {
                     return true;
                 }
             }
         } catch (UnknownHostException e) {
-            return true; // Block if can't resolve
+            return true;
         }
         return false;
     }

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpRequest.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpRequest.java
@@ -866,17 +866,36 @@ public class RDAPHttpRequest {
             localBindIp = InetAddress.getByName(LOCAL_IPv4);
         }
 
-        if (qctx.isSsrfProtectionEnabled() && (remoteAddress.isLoopbackAddress() ||
-                remoteAddress.isSiteLocalAddress() ||
-                remoteAddress.isLinkLocalAddress() ||
-                remoteAddress.isAnyLocalAddress() ||
-                RDAPHttpQuery.isIPv6UniqueLocalAddress(remoteAddress) ||
-                AWS_GATEWAY_IP.equals(remoteAddress.getHostAddress()))) {
-            logger.warn("Blocked connection to internal/private IP: {}", remoteAddress.getHostAddress());
-            tracker.completeTrackingById(trackingId, ZERO, ConnectionStatus.UNKNOWN_HOST);
-            SimpleHttpResponse resp = new SimpleHttpResponse(trackingId, ZERO, EMPTY_STRING, originalUri, new Header[ZERO]);
-            resp.setConnectionStatusCode(ConnectionStatus.UNKNOWN_HOST);
-            return resp;
+        if (qctx.isSsrfProtectionEnabled()) {
+            String resolvedIp = remoteAddress.getHostAddress();
+            String resolvedHost = originalUri.getHost();
+
+            // Check allowlist first (for QA/testing environments)
+            boolean isAllowed = qctx.getSsrfAllowedHosts().contains(resolvedIp) ||
+                    qctx.getSsrfAllowedHosts().contains(resolvedHost.toLowerCase());
+
+            if (!isAllowed) {
+                // Check the specific remote address being used
+                boolean directlyBlocked = remoteAddress.isLoopbackAddress() ||
+                        remoteAddress.isSiteLocalAddress() ||
+                        remoteAddress.isLinkLocalAddress() ||
+                        remoteAddress.isAnyLocalAddress() ||
+                        RDAPHttpQuery.isIPv6UniqueLocalAddress(remoteAddress) ||
+                        AWS_GATEWAY_IP.equals(resolvedIp);
+
+                // Cross-family check: if ANY resolved IP for this hostname is private,
+                // block ALL connections to it regardless of which address family is used.
+                // This prevents IPv6 bypass when the same host also has a private IPv4.
+                boolean crossFamilyBlocked = isAnyResolvedAddressPrivate(qctx, resolvedHost);
+
+                if (directlyBlocked || crossFamilyBlocked) {
+                    logger.warn("Blocked connection to internal/private IP: {} (host: {})", resolvedIp, resolvedHost);
+                    tracker.completeTrackingById(trackingId, ZERO, ConnectionStatus.UNKNOWN_HOST);
+                    SimpleHttpResponse resp = new SimpleHttpResponse(trackingId, ZERO, EMPTY_STRING, originalUri, new Header[ZERO]);
+                    resp.setConnectionStatusCode(ConnectionStatus.UNKNOWN_HOST);
+                    return resp;
+                }
+            }
         }
 
         URI ipUri = new URI(
@@ -976,6 +995,39 @@ public class RDAPHttpRequest {
         // If all retries are exhausted
         tracker.completeTrackingById(trackingId, HTTP_TOO_MANY_REQUESTS, ConnectionStatus.TOO_MANY_REQUESTS);
         return new SimpleHttpResponse(trackingId, HTTP_TOO_MANY_REQUESTS, EMPTY_STRING, originalUri, new Header[ZERO]);
+    }
+
+    /**
+     * Checks if ANY resolved address for the given hostname (across both IPv4 and IPv6)
+     * falls into a private/reserved range.
+     *
+     * This cross-family check prevents SSRF bypass scenarios where a hostname resolves
+     * to both a private IPv4 (e.g., 10.x.x.x) and a public IPv6 address. An attacker
+     * (or internal test server) could exploit the IPv6 path to reach an otherwise
+     * blocked internal service.
+     *
+     * @param qctx the QueryContext providing DNS resolver access
+     * @param host the hostname to check
+     * @return true if any resolved IP is private/reserved, false if all are public
+     */
+    private static boolean isAnyResolvedAddressPrivate(QueryContext qctx, String host) {
+        List<InetAddress> allAddresses = new ArrayList<>();
+        allAddresses.addAll(qctx.getDnsResolver().getAllV4Addresses(host));
+        allAddresses.addAll(qctx.getDnsResolver().getAllV6Addresses(host));
+
+        for (InetAddress addr : allAddresses) {
+            if (addr.isLoopbackAddress() ||
+                    addr.isSiteLocalAddress() ||
+                    addr.isLinkLocalAddress() ||
+                    addr.isAnyLocalAddress() ||
+                    RDAPHttpQuery.isIPv6UniqueLocalAddress(addr) ||
+                    AWS_GATEWAY_IP.equals(addr.getHostAddress())) {
+                logger.debug("Cross-family SSRF block triggered: {} has private address {}",
+                        host, addr.getHostAddress());
+                return true;
+            }
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
## Required Information

### PR Description (Include comprehensive description)

#### Summary of changes:
fix(security): harden SSRF protection to block private-IP bypass via IPv6

Resolves an SSRF vulnerability where HTTP redirect destinations and
dual-stack hosts could bypass IP validation by resolving to a publicly
routable IPv6 address that maps to an internal service.

Changes:
- RDAPValidatorConfiguration: add default getSsrfAllowedHosts() returning
  empty list, enabling per-environment allowlist configuration
- QueryContext: add ssrfAllowedHosts Set<String> with addSsrfAllowedHost()
  and getSsrfAllowedHosts(); propagate allowlist from config on construction
- RDAPHttpRequest: refactor SSRF guard to check allowlist before blocking;
  add isAnyResolvedAddressPrivate() cross-family helper that inspects all
  resolved IPv4 and IPv6 addresses for a hostname — if any is private the
  connection is blocked regardless of which address family is used
- RDAPHttpQuery.isBlockedRedirectDestination(): apply same allowlist check
  before blocking redirect destinations
- RdapConformanceTool: add --ssrf-allowed-hosts CLI option (repeatable) and
  override getSsrfAllowedHosts() to expose it through configuration

Security impact: previously a host with both a private IPv4 (10.x.x.x) and
a public IPv6 could reach internal services via the IPv6 path. The cross-
family check closes this gap. QA environments can opt-in specific hosts via
--ssrf-allowed-hosts without disabling SSRF protection globally.
#### Problem/feature addressed:
Problem: https://icann-jira.atlassian.net/browse/RCT-484?focusedCommentId=305013

If the IPv6 path reaches the same WireMock service as the blocked IPv4 path, then it is an SSRF bypass even if it currently passes validation. The control needs to return the same allow or block decision regardless of whether resolution happens over IPv4 or IPv6.

The expected behavior is that SSRF validation blocks disallowed destinations across both address families and revalidates each redirect target on every hop. If WireMock needs to stay reachable in local or QA, we should handle that through a test-only allowlist or exception rather than through a gap in validation.
#### Relevant screenshots/diagrams:

#### Links to relevant issues/tasks:
https://icann-jira.atlassian.net/browse/RCT-484
### Branch Name

- [x] Does the branch name follow the Branch Naming Convention?

#### If not, explain why:

### Code Changes

- [x] Are code changes adhering to coding standards and practices?

#### If not, explain why:

### Commit Messages

- [ ] Do commit messages follow [Conventional Commits guidelines](https://wecann.icann.org/docs/DOC-40501)?
- [x] Are they clear, concise, and informative using imperative language?

#### If not, explain why:

### Tests and Test Coverage

- [x] Are changes covered by appropriate tests?
- [ ] Were unit tests, integration tests, and end-to-end tests run?
- [ ] Was the test coverage maintained or improved? Please include before/after results.

#### If not, explain why:

### Bug Fixes and Tests

- [ ] For bug fixes, are there:
    - [ ] Tests that reproduce the bug before the changes?
    - [ ] Tests that demonstrate the bug is resolved after the changes?

#### If not, explain why:

### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Documentation

- [ ] Are there updates to documentation that need to be made?
- [x] Are they included or linked in the PR description?

#### If not, explain why:

### PR Size

- [x] Is the PR small and focused on one logical change?

#### If not, explain why:

---