### PR TITLE
feat: RCT-491 Remove 2019 profile command line parameter from the CLI

### DIFF
--- a/doc/codes.md
+++ b/doc/codes.md
@@ -19,7 +19,6 @@ Each error code has been systematically mapped to the most appropriate RFC secti
 - **RFC 3915** (Domain Registry Grace Period Mapping for EPP)
 
 ### Profile Documents Referenced:
-- **RDAP Response Profile 2019**
 - **RDAP Response Profile 2024**
 - **Technical Implementation Guide (TIG)** - ICANN RDAP Technical Implementation Guide
 
@@ -522,7 +521,7 @@ The following 5 parsers are test files or do not generate error codes:
 
 ## Profile Differences
 
-### 2019 Profile vs 2024 Profile
+### 2024 Profile
 - Many validation classes have separate 2024 versions with enhanced checks
 - 2024 profile introduces new error codes (e.g., `-12610`, `-61100`, `-61101`)
 - 2024 profile has stricter requirements for error responses
@@ -610,7 +609,7 @@ The RDAP Conformance Tool uses a systematic numbering scheme for its 361 documen
 
 ### Profile Differences Summary
 
-#### 2019 Profile vs 2024 Profile
+####  2024 Profile
 - **2024 Profile introduces 118+ new error codes** primarily in the -63XXX, -64XXX, and -65XXX ranges for vCard and redaction validation
 - **Enhanced SSL/TLS validation** with specific cipher suite requirements (-61100, -61101)
 - **Stricter error response requirements** (-12107 for mandatory rdapConformance, -12108 for errorCode matching HTTP status)

--- a/doc/process_flow.md
+++ b/doc/process_flow.md
@@ -16,12 +16,11 @@ This document describes the process flow of the RDAP Conformance Tool CLI, from 
 10. [Schema Validation](#schema-validation)
 11. [SSL/TLS Validation](#ssltls-validation)
 12. [Profile Validation](#profile-validation)
-13. [Profile Differences (2019 vs 2024)](#profile-differences-2019-vs-2024)
-14. [Multiple Validation Rounds](#multiple-validation-rounds)
-15. [Results Collection](#results-collection)
-16. [Exit Codes](#exit-codes)
-17. [Web API Entry Point (RdapWebValidator)](#web-api-entry-point-rdapwebvalidator)
-18. [Key Design Patterns](#key-design-patterns)
+13. [Multiple Validation Rounds](#multiple-validation-rounds)
+14. [Results Collection](#results-collection)
+15. [Exit Codes](#exit-codes)
+16. [Web API Entry Point (RdapWebValidator)](#web-api-entry-point-rdapwebvalidator)
+17. [Key Design Patterns](#key-design-patterns)
 
 ## Overview
 
@@ -30,7 +29,7 @@ The RDAP Conformance Tool validates RDAP (Registration Data Access Protocol) ser
 1. Downloads IANA reference datasets
 2. Makes HTTP queries to the target RDAP server
 3. Validates responses against JSON schemas
-4. Validates responses against profile requirements (2019 or 2024)
+4. Validates responses against profile requirements (2024)
 5. Generates a JSON results file with errors, warnings, and notes
 
 ```
@@ -107,7 +106,6 @@ The tool uses picocli `@Command` and `@Option` annotations for argument parsing.
 | `--gtld-registrar` | false | Enable gTLD Registrar profile |
 | `--gtld-registry` | false | Enable gTLD Registry profile |
 | `--thin` | false | TLD uses thin registration model |
-| `--use-rdap-profile-february-2019` | false | Use 2019 RDAP profile |
 | `--use-rdap-profile-february-2024` | false | Use 2024 RDAP profile |
 | `--no-ipv4-queries` | false | Skip IPv4 queries |
 | `--no-ipv6-queries` | false | Skip IPv6 queries |
@@ -373,7 +371,7 @@ For HTTPS connections, the tool performs SSL/TLS validation as part of the TIG (
 
 **File**: `validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/ProfileValidation.java`
 
-After schema validation, the tool runs profile-specific validations based on the selected RDAP profile (2019 or 2024).
+After schema validation, the tool runs profile-specific validations based on the selected RDAP profile (2024).
 
 ### Validation Categories
 
@@ -397,10 +395,6 @@ Each `ProfileValidation` implementation:
 3. Execute doValidate() - actual validation logic
 4. Catch exceptions and report as group error
 ```
-
-## Profile Differences (2019 vs 2024)
-
-The tool supports two RDAP profiles with significant differences:
 
 ### 2024 Profile Additions
 
@@ -429,7 +423,7 @@ The following 2019 validations were removed or replaced:
 
 Both profiles can be enabled simultaneously using:
 ```bash
---use-rdap-profile-february-2019 --use-rdap-profile-february-2024
+--use-rdap-profile-february-2024
 ```
 
 This allows comparative testing to identify differences in validation results between profiles.
@@ -492,7 +486,6 @@ Results are written to a JSON file with timestamp: `results-YYYYMMDDHHmmss.json`
     "testedURI": "https://rdap.example.com/domain/example.com",
     "definitionIdentifier": "Standard gTLD RDAP Server Conformance",
     "rdapProfileFebruary2024": true,
-    "rdapProfileFebruary2019": false,
     "gtldRegistry": true,
     "gtldRegistrar": false,
     "thinRegistry": false,
@@ -556,7 +549,7 @@ For web applications (like the RDAP Conformance Tool Frontend), the `RdapWebVali
 
 **ConfigurableRDAPValidatorConfiguration**: Extended settings
 - All of `SimpleRDAPValidatorConfiguration` plus:
-- `rdapProfile2019` / `rdapProfile2024` - Profile selection
+- `rdapProfile2024` - Profile selection
 - `tempDir` - Custom temporary directory
 
 ### Validation Flow

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     </distributionManagement>
 
     <properties>
-        <rdap-conformance.version>3.1.2</rdap-conformance.version>
+        <rdap-conformance.version>3.1.3</rdap-conformance.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 

--- a/tool/README.md
+++ b/tool/README.md
@@ -8,7 +8,7 @@ Usage: rdap-conformance-tool [-hV] [--use-local-datasets]
                              -c=<configurationFile>
                              [--maximum-redirects=<maxRedirects>]
                              [--timeout=<timeout>]
-                             [[--use-rdap-profile-february-2019]
+                             [[--use-rdap-profile-february-2024]
                              ([--gtld-registrar] | [--gtld-registry [--thin]])]
                              RDAP_URI
       RDAP_URI               The URI to be tested
@@ -24,8 +24,6 @@ Usage: rdap-conformance-tool [-hV] [--use-local-datasets]
       --thin                 The TLD uses the thin model
       --timeout=<timeout>    Timeout for connecting to the server
       --use-local-datasets   Use locally-persisted datasets
-      --use-rdap-profile-february-2019
-                             Use RDAP Profile February 2019
   -V, --version              Print version information and exit.
 ```
 

--- a/tool/src/main/java/org/icann/rdapconformance/tool/RdapConformanceTool.java
+++ b/tool/src/main/java/org/icann/rdapconformance/tool/RdapConformanceTool.java
@@ -66,7 +66,7 @@ import static org.icann.rdapconformance.validator.CommonUtils.*;
  *
  * <p>The tool can validate RDAP responses from live servers via HTTP or from local JSON files.
  * It supports both gTLD registry and registrar profiles, with options for different RDAP
- * profile versions (February 2019 and February 2024).</p>
+ * profile versions (February 2024).</p>
  *
  * <p><strong>For Web Applications: Use {@link RdapWebValidator} instead</strong></p>
  * <pre>{@code
@@ -275,15 +275,6 @@ public void setUseRdapProfileFeb2024(boolean value) {
 }
 
 /**
- * Sets whether to use the RDAP Profile February 2019 specification.
- *
- * @param value true to use February 2019 profile
- */
-public void setUseRdapProfileFeb2019(boolean value) {
-    this.dependantRdapProfileGtld.exclusiveRdapProfile.dependantRdapProfile.useRdapProfileFeb2019 = value;
-}
-
-/**
  * Configures validation for gTLD registry responses.
  *
  * @param value true to validate as gTLD registry
@@ -351,7 +342,7 @@ public void setShowProgress(boolean showProgress) {
    * </ol>
    *
    * <p>The tool validates RDAP responses against the appropriate specification profile
-   * (February 2019 or February 2024) and generates a comprehensive results file containing
+   * (February 2024) and generates a comprehensive results file containing
    * errors, warnings, and validation details.</p>
    *
    * @return exit code: 0 for success, non-zero for various error conditions
@@ -829,10 +820,6 @@ public void setShowProgress(boolean showProgress) {
   }
 
   @Override
-  public boolean useRdapProfileFeb2019() {
-    return this.dependantRdapProfileGtld.exclusiveRdapProfile.dependantRdapProfile.useRdapProfileFeb2019;}
-
-  @Override
   public boolean useRdapProfileFeb2024() { return this.dependantRdapProfileGtld.exclusiveRdapProfile.dependantRdapProfile.useRdapProfileFeb2024; }
 
 
@@ -1035,9 +1022,6 @@ public void setShowProgress(boolean showProgress) {
   }
 
   private static class DependantRdapProfile {
-    @Option(names = {"--use-rdap-profile-february-2019"},
-            description = "Use RDAP Profile February 2019", defaultValue = "false")
-    boolean useRdapProfileFeb2019 = false;
     @Option(names = {"--use-rdap-profile-february-2024"},
             description = "Use RDAP Profile February 2024", defaultValue = "false", required = true)
     private boolean useRdapProfileFeb2024 = false;

--- a/tool/src/main/java/org/icann/rdapconformance/tool/RdapWebValidator.java
+++ b/tool/src/main/java/org/icann/rdapconformance/tool/RdapWebValidator.java
@@ -121,7 +121,6 @@ public class RdapWebValidator implements AutoCloseable {
      * @param uri the RDAP URI to validate
      * @param isRegistry true if this is a gTLD registry
      * @param isRegistrar true if this is a gTLD registrar
-     * @param useRdapProfileFeb2019 true to use RDAP Profile Feb 2019
      * @param useRdapProfileFeb2024 true to use RDAP Profile Feb 2024
      * @param noIpv4Queries true to disable IPv4 queries
      * @param noIpv6Queries true to disable IPv6 queries
@@ -132,12 +131,12 @@ public class RdapWebValidator implements AutoCloseable {
      * @throws RuntimeException if the configuration is invalid or temp directory creation fails
      */
     public RdapWebValidator(URI uri, boolean isRegistry, boolean isRegistrar,
-                           boolean useRdapProfileFeb2019, boolean useRdapProfileFeb2024,
+                           boolean useRdapProfileFeb2024,
                            boolean noIpv4Queries, boolean noIpv6Queries,
                            boolean additionalConformanceQueries,
                            boolean useTemporaryDirectory, boolean cleanupOnClose) {
         this(uri, new ConfigurableRDAPValidatorConfiguration(uri, isRegistry, isRegistrar, false,
-                                                           useRdapProfileFeb2019, useRdapProfileFeb2024,
+                                                            useRdapProfileFeb2024,
                                                            noIpv4Queries, noIpv6Queries,
                                                            additionalConformanceQueries),
              useTemporaryDirectory ? createTempDirectory() : null, cleanupOnClose);
@@ -463,9 +462,6 @@ public class RdapWebValidator implements AutoCloseable {
         public boolean useLocalDatasets() { return false; }
 
         @Override
-        public boolean useRdapProfileFeb2019() { return false; }
-
-        @Override
         public boolean useRdapProfileFeb2024() { return true; }
 
         @Override
@@ -520,7 +516,6 @@ public class RdapWebValidator implements AutoCloseable {
         private final boolean isRegistry;
         private final boolean isRegistrar;
         private final boolean useLocalDatasets;
-        private final boolean useRdapProfileFeb2019;
         private final boolean useRdapProfileFeb2024;
         private final boolean noIpv4Queries;
         private final boolean noIpv6Queries;
@@ -532,7 +527,6 @@ public class RdapWebValidator implements AutoCloseable {
 
         public ConfigurableRDAPValidatorConfiguration(URI uri, boolean isRegistry, boolean isRegistrar, boolean useLocalDatasets) {
             this(uri, isRegistry, isRegistrar, useLocalDatasets,
-                 false, // useRdapProfileFeb2019 - default to false
                  true,  // useRdapProfileFeb2024 - default to true
                  false, // noIpv4Queries - default to false (IPv4 enabled)
                  false, // noIpv6Queries - default to false (IPv6 enabled)
@@ -541,15 +535,13 @@ public class RdapWebValidator implements AutoCloseable {
         }
 
         public ConfigurableRDAPValidatorConfiguration(URI uri, boolean isRegistry, boolean isRegistrar,
-                                                    boolean useLocalDatasets,
-                                                    boolean useRdapProfileFeb2019, boolean useRdapProfileFeb2024,
+                                                    boolean useLocalDatasets,boolean useRdapProfileFeb2024,
                                                     boolean noIpv4Queries, boolean noIpv6Queries,
                                                     boolean additionalConformanceQueries) {
             this.uri = uri;
             this.isRegistry = isRegistry;
             this.isRegistrar = isRegistrar;
             this.useLocalDatasets = useLocalDatasets;
-            this.useRdapProfileFeb2019 = useRdapProfileFeb2019;
             this.useRdapProfileFeb2024 = useRdapProfileFeb2024;
             this.noIpv4Queries = noIpv4Queries;
             this.noIpv6Queries = noIpv6Queries;
@@ -573,9 +565,6 @@ public class RdapWebValidator implements AutoCloseable {
 
         @Override
         public boolean useLocalDatasets() { return useLocalDatasets; }
-
-        @Override
-        public boolean useRdapProfileFeb2019() { return useRdapProfileFeb2019; }
 
         @Override
         public boolean useRdapProfileFeb2024() { return useRdapProfileFeb2024; }

--- a/tool/src/main/java/org/icann/rdapconformance/tool/RdapWebValidator.java
+++ b/tool/src/main/java/org/icann/rdapconformance/tool/RdapWebValidator.java
@@ -535,7 +535,7 @@ public class RdapWebValidator implements AutoCloseable {
         }
 
         public ConfigurableRDAPValidatorConfiguration(URI uri, boolean isRegistry, boolean isRegistrar,
-                                                    boolean useLocalDatasets,boolean useRdapProfileFeb2024,
+                                                    boolean useLocalDatasets, boolean useRdapProfileFeb2024,
                                                     boolean noIpv4Queries, boolean noIpv6Queries,
                                                     boolean additionalConformanceQueries) {
             this.uri = uri;

--- a/tool/src/test/java/org/icann/rdapconformance/tool/RdapConformanceToolArgsTest.java
+++ b/tool/src/test/java/org/icann/rdapconformance/tool/RdapConformanceToolArgsTest.java
@@ -30,36 +30,6 @@ public class RdapConformanceToolArgsTest {
   }
 
   @Test
-  public void testUseRdapProfileArg_RequiresGtldRegistryOrGtldRegistrar() {
-    String[] args = "--config=/tmp/test --use-rdap-profile-february-2019 http://example.org"
-        .split(" ");
-
-    assertThatExceptionOfType(MissingParameterException.class).isThrownBy(
-        () -> new CommandLine(new RdapConformanceTool()).parseArgs(args))
-        .withMessageStartingWith("Error: Missing required argument(s): ");
-  }
-
-  @Test
-  public void testUseRdapProfileArg_WithGtldRegistry_isOK() {
-    String[] args = "--config=/tmp/test --use-rdap-profile-february-2019 --gtld-registry http://example.org"
-        .split(" ");
-
-    assertThatCode(() -> new CommandLine(new RdapConformanceTool()).parseArgs(args))
-        .doesNotThrowAnyException();
-
-  }
-
-  @Test
-  public void testUseRdapProfileArg_WithGtldRegistrar_isOK() {
-    String[] args = "--config=/tmp/test --use-rdap-profile-february-2019 --gtld-registrar http://example.org"
-        .split(" ");
-
-    assertThatCode(() -> new CommandLine(new RdapConformanceTool()).parseArgs(args))
-        .doesNotThrowAnyException();
-  }
-
-
-  @Test
   public void testGtldRegistryAndGtldRegistrarArgs_AreExclusive() {
     String[] args = "--config=/tmp/test --gtld-registry --gtld-registrar http://example.org"
         .split(" ");
@@ -81,7 +51,7 @@ public class RdapConformanceToolArgsTest {
 
   @Test
   public void testThinArg_WithGtldRegistry_IsOk() {
-    String[] args = "--config=/tmp/test --thin --gtld-registry http://example.org --use-rdap-profile-february-2019".split(" ");
+    String[] args = "--config=/tmp/test --thin --gtld-registry http://example.org --use-rdap-profile-february-2024".split(" ");
 
     assertThatCode(() -> new CommandLine(new RdapConformanceTool()).parseArgs(args))
         .doesNotThrowAnyException();
@@ -89,7 +59,7 @@ public class RdapConformanceToolArgsTest {
 
   @Test
   public void testAdditionalConformanceQueries_Arg_IsOk() {
-    String[] args = "--config=/tmp/test --thin --gtld-registry http://example.org --use-rdap-profile-february-2019 --additional-conformance-queries".split(" ");
+    String[] args = "--config=/tmp/test --thin --gtld-registry http://example.org --use-rdap-profile-february-2024 --additional-conformance-queries".split(" ");
 
     assertThatCode(() -> new CommandLine(new RdapConformanceTool()).parseArgs(args))
             .doesNotThrowAnyException();

--- a/tool/src/test/java/org/icann/rdapconformance/tool/RdapWebValidatorTest.java
+++ b/tool/src/test/java/org/icann/rdapconformance/tool/RdapWebValidatorTest.java
@@ -401,7 +401,6 @@ public class RdapWebValidatorTest {
         try (RdapWebValidator validator = new RdapWebValidator(testUri,
                 true,    // isRegistry
                 false,   // isRegistrar
-                true,    // useRdapProfileFeb2019
                 false,   // useRdapProfileFeb2024
                 true,    // noIpv4Queries
                 false,   // noIpv6Queries
@@ -416,7 +415,6 @@ public class RdapWebValidatorTest {
             assertEquals(testUri, validator.getUri());
             assertTrue(validator.getQueryContext().getConfig().isGtldRegistry());
             assertFalse(validator.getQueryContext().getConfig().isGtldRegistrar());
-            assertTrue(validator.getQueryContext().getConfig().useRdapProfileFeb2019());
             assertFalse(validator.getQueryContext().getConfig().useRdapProfileFeb2024());
             assertTrue(validator.getQueryContext().getConfig().isNoIpv4Queries());
             assertFalse(validator.getQueryContext().getConfig().isNoIpv6Queries());
@@ -432,7 +430,6 @@ public class RdapWebValidatorTest {
         try (RdapWebValidator validator = new RdapWebValidator(testUri,
                 false,   // isRegistry
                 true,    // isRegistrar
-                false,   // useRdapProfileFeb2019 (default)
                 true,    // useRdapProfileFeb2024 (default)
                 false,   // noIpv4Queries (default)
                 false,   // noIpv6Queries (default)
@@ -445,7 +442,6 @@ public class RdapWebValidatorTest {
             // Verify configuration values match what we set
             assertFalse(validator.getQueryContext().getConfig().isGtldRegistry());
             assertTrue(validator.getQueryContext().getConfig().isGtldRegistrar());
-            assertFalse(validator.getQueryContext().getConfig().useRdapProfileFeb2019());
             assertTrue(validator.getQueryContext().getConfig().useRdapProfileFeb2024());
             assertFalse(validator.getQueryContext().getConfig().isNoIpv4Queries());
             assertFalse(validator.getQueryContext().getConfig().isNoIpv6Queries());
@@ -457,25 +453,10 @@ public class RdapWebValidatorTest {
     public void testProfileConfigurationOptions() {
         URI testUri = URI.create("https://rdap.example.com/domain/test.example");
 
-        // Test RDAP Profile 2019 enabled
-        try (RdapWebValidator validator2019 = new RdapWebValidator(testUri,
-                true, false, true, false, false, false, false, false, false)) {
-            assertTrue(validator2019.getQueryContext().getConfig().useRdapProfileFeb2019());
-            assertFalse(validator2019.getQueryContext().getConfig().useRdapProfileFeb2024());
-        }
-
         // Test RDAP Profile 2024 enabled
         try (RdapWebValidator validator2024 = new RdapWebValidator(testUri,
-                true, false, false, true, false, false, false, false, false)) {
-            assertFalse(validator2024.getQueryContext().getConfig().useRdapProfileFeb2019());
+                true, false, true, false, false, false, false, false)) {
             assertTrue(validator2024.getQueryContext().getConfig().useRdapProfileFeb2024());
-        }
-
-        // Test both profiles enabled
-        try (RdapWebValidator validatorBoth = new RdapWebValidator(testUri,
-                true, false, true, true, false, false, false, false, false)) {
-            assertTrue(validatorBoth.getQueryContext().getConfig().useRdapProfileFeb2019());
-            assertTrue(validatorBoth.getQueryContext().getConfig().useRdapProfileFeb2024());
         }
     }
 
@@ -485,21 +466,21 @@ public class RdapWebValidatorTest {
 
         // Test IPv4 disabled
         try (RdapWebValidator validatorNoIPv4 = new RdapWebValidator(testUri,
-                true, false, false, true, true, false, false, false, false)) {
+                true, false, true, true, false, false, false, false)) {
             assertTrue(validatorNoIPv4.getQueryContext().getConfig().isNoIpv4Queries());
             assertFalse(validatorNoIPv4.getQueryContext().getConfig().isNoIpv6Queries());
         }
 
         // Test IPv6 disabled
         try (RdapWebValidator validatorNoIPv6 = new RdapWebValidator(testUri,
-                true, false, false, true, false, true, false, false, false)) {
+                true, false, true, false, true, false, false, false)) {
             assertFalse(validatorNoIPv6.getQueryContext().getConfig().isNoIpv4Queries());
             assertTrue(validatorNoIPv6.getQueryContext().getConfig().isNoIpv6Queries());
         }
 
         // Test both IP versions disabled
         try (RdapWebValidator validatorNoIP = new RdapWebValidator(testUri,
-                true, false, false, true, true, true, false, false, false)) {
+                true, false, true, true, true, false, false, false)) {
             assertTrue(validatorNoIP.getQueryContext().getConfig().isNoIpv4Queries());
             assertTrue(validatorNoIP.getQueryContext().getConfig().isNoIpv6Queries());
         }
@@ -511,13 +492,13 @@ public class RdapWebValidatorTest {
 
         // Test additional conformance queries enabled
         try (RdapWebValidator validator = new RdapWebValidator(testUri,
-                true, false, false, true, false, false, true, false, false)) {
+                true, false, true, false, false, true, false, false)) {
             assertTrue(validator.getQueryContext().getConfig().isAdditionalConformanceQueries());
         }
 
         // Test additional conformance queries disabled (default)
         try (RdapWebValidator validator = new RdapWebValidator(testUri,
-                true, false, false, true, false, false, false, false, false)) {
+                true, false, true, false, false, false, false, false)) {
             assertFalse(validator.getQueryContext().getConfig().isAdditionalConformanceQueries());
         }
     }
@@ -530,7 +511,6 @@ public class RdapWebValidatorTest {
         try (RdapWebValidator validator = new RdapWebValidator(testUri,
                 false,   // isRegistry
                 true,    // isRegistrar
-                true,    // useRdapProfileFeb2019
                 true,    // useRdapProfileFeb2024
                 true,    // noIpv4Queries
                 true,    // noIpv6Queries
@@ -543,7 +523,6 @@ public class RdapWebValidatorTest {
             // Verify all configuration options are set as expected
             assertFalse(validator.getQueryContext().getConfig().isGtldRegistry());
             assertTrue(validator.getQueryContext().getConfig().isGtldRegistrar());
-            assertTrue(validator.getQueryContext().getConfig().useRdapProfileFeb2019());
             assertTrue(validator.getQueryContext().getConfig().useRdapProfileFeb2024());
             assertTrue(validator.getQueryContext().getConfig().isNoIpv4Queries());
             assertTrue(validator.getQueryContext().getConfig().isNoIpv6Queries());
@@ -565,7 +544,6 @@ public class RdapWebValidatorTest {
         try (RdapWebValidator validator = new RdapWebValidator(testUri,
                 true,    // isRegistry
                 false,   // isRegistrar
-                false,   // useRdapProfileFeb2019
                 true,    // useRdapProfileFeb2024
                 false,   // noIpv4Queries
                 false,   // noIpv6Queries

--- a/validator/src/main/java/org/icann/rdapconformance/validator/ConnectionTracker.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/ConnectionTracker.java
@@ -513,7 +513,7 @@ public class ConnectionTracker {
                 // It's ok to return true here so we can log the message in verbose mode
                 // If a profile is used, and both HEAD and GET result in 404, then this should be a warning
                 if((HEAD.equalsIgnoreCase(record.getHttpMethod()) || GET.equalsIgnoreCase(record.getHttpMethod()))
-                        && (config.useRdapProfileFeb2024() || config.useRdapProfileFeb2019())
+                        && (config.useRdapProfileFeb2024())
                         && (config.isGtldRegistrar() || config.isGtldRegistry())) {
                     queryContext.addError(record.getStatusCode(), -13020, config.getUri().toString(), "This URL returned an HTTP 404 status code that was validly formed. If the provided URL "
                             + "does not reference a registered resource, then this warning may be ignored. If the provided URL does reference a registered resource, then this should be considered an error.");

--- a/validator/src/main/java/org/icann/rdapconformance/validator/configuration/ConfigurationFile.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/configuration/ConfigurationFile.java
@@ -63,7 +63,6 @@ public class ConfigurationFile {
   private final boolean gtldRegistrar;
   private final boolean gtldRegistry;
   private final boolean thinRegistry;
-  private final boolean rdapProfileFebruary2019;
   private final boolean rdapProfileFebruary2024;
 
   @JsonCreator
@@ -76,7 +75,6 @@ public class ConfigurationFile {
       @JsonProperty(value = "gtldRegistrar") boolean gtldRegistrar,
       @JsonProperty(value = "gtldRegistry") boolean gtldRegistry,
       @JsonProperty(value = "thinRegistry") boolean thinRegistry,
-      @JsonProperty(value = "rdapProfileFebruary2019") boolean rdapProfileFebruary2019,
       @JsonProperty(value = "rdapProfileFebruary2024") boolean rdapProfileFebruary2024) {
     this.definitionIdentifier = definitionIdentifier;
     this.definitionError = emptyListIfNull(definitionError);
@@ -86,7 +84,6 @@ public class ConfigurationFile {
     this.gtldRegistrar = gtldRegistrar;
     this.gtldRegistry = gtldRegistry;
     this.thinRegistry = thinRegistry;
-    this.rdapProfileFebruary2019 = rdapProfileFebruary2019;
     this.rdapProfileFebruary2024 = rdapProfileFebruary2024;
     if (null != definitionError) {
       this.errorCodes = definitionError.stream()
@@ -155,10 +152,6 @@ public class ConfigurationFile {
 
   public boolean isThinRegistry() {
     return thinRegistry;
-  }
-
-  public boolean isRdapProfileFebruary2019() {
-    return rdapProfileFebruary2019;
   }
 
   public boolean isRdapProfileFebruary2024() {

--- a/validator/src/main/java/org/icann/rdapconformance/validator/configuration/RDAPValidatorConfiguration.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/configuration/RDAPValidatorConfiguration.java
@@ -26,7 +26,6 @@ public interface RDAPValidatorConfiguration {
 
   boolean useLocalDatasets();
 
-  boolean useRdapProfileFeb2019();
   boolean useRdapProfileFeb2024();
 
   boolean isGtldRegistrar();
@@ -122,11 +121,6 @@ public interface RDAPValidatorConfiguration {
       logger.error("Thin only applies for gTLD registry");
       return false;
     }
-    if (useRdapProfileFeb2019() && !(isGtldRegistry() || isGtldRegistrar())) {
-      logger.error("RDAP profile February 2019 need gTLD type to be specified");
-      return false;
-    }
-
     // transform URI host from U-label to A-label if necessary, ignore errors
     if (null == getUri().getHost() && null != getUri().getAuthority()) {
       // for U-label, URI host is null

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidationResultFile.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidationResultFile.java
@@ -192,7 +192,6 @@ public class RDAPValidationResultFile {
         fileMap.put("gtldRegistrar", config.isGtldRegistrar());
         fileMap.put("gtldRegistry", config.isGtldRegistry());
         fileMap.put("thinRegistry", config.isThin());
-        fileMap.put("rdapProfileFebruary2019", config.useRdapProfileFeb2019());
         fileMap.put("rdapProfileFebruary2024", config.useRdapProfileFeb2024());
         fileMap.put("additionalConformanceQueries", config.isAdditionalConformanceQueries());
         fileMap.put("noIpv4", config.isNoIpv4Queries());

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidator.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidator.java
@@ -34,28 +34,17 @@ import org.icann.rdapconformance.validator.workflow.DomainCaseFoldingValidation;
 import org.icann.rdapconformance.validator.workflow.ValidatorWorkflow;
 import org.icann.rdapconformance.validator.workflow.profile.ProfileValidation;
 import org.icann.rdapconformance.validator.workflow.profile.RDAPProfile;
-import org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain.entities.ResponseValidation2Dot7Dot1DotXAndRelated1;
-import org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain.entities.ResponseValidation2Dot7Dot1DotXAndRelated2;
-import org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain.entities.ResponseValidation2Dot7Dot1DotXAndRelated3And4;
-import org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain.entities.ResponseValidation2Dot7Dot1DotXAndRelated5;
 import org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain.entities.ResponseValidation2Dot7Dot1DotXAndRelated6;
-import org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain.entities.ResponseValidation2Dot7Dot5Dot2;
-import org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain.entities.ResponseValidation2Dot7Dot5Dot3;
-import org.icann.rdapconformance.validator.workflow.profile.rdap_response.entity.ResponseValidation3Dot1;
-import org.icann.rdapconformance.validator.workflow.profile.rdap_response.entity.ResponseValidation3Dot2;
 import org.icann.rdapconformance.validator.workflow.profile.rdap_response.miscellaneous.ResponseValidationLastUpdateEvent;
 import org.icann.rdapconformance.validator.workflow.profile.rdap_response.nameserver.ResponseNameserverStatusValidation;
 import org.icann.rdapconformance.validator.workflow.profile.rdap_response.nameserver.ResponseValidation4Dot1Handle;
 import org.icann.rdapconformance.validator.workflow.profile.rdap_response.nameserver.ResponseValidation4Dot1Query;
 import org.icann.rdapconformance.validator.workflow.profile.rdap_response.nameserver.ResponseValidation4Dot3;
 import org.icann.rdapconformance.validator.workflow.profile.tig_section.general.TigValidation1Dot13;
-import org.icann.rdapconformance.validator.workflow.profile.tig_section.general.TigValidation1Dot14;
 import org.icann.rdapconformance.validator.workflow.profile.tig_section.general.TigValidation1Dot2;
-import org.icann.rdapconformance.validator.workflow.profile.tig_section.general.TigValidation1Dot3;
 import org.icann.rdapconformance.validator.workflow.profile.tig_section.general.TigValidation1Dot3_2024;
 import org.icann.rdapconformance.validator.workflow.profile.tig_section.general.TigValidation1Dot6;
 import org.icann.rdapconformance.validator.workflow.profile.tig_section.general.TigValidation1Dot8;
-import org.icann.rdapconformance.validator.workflow.profile.tig_section.general.TigValidation3Dot3And3Dot4;
 import org.icann.rdapconformance.validator.workflow.profile.tig_section.general.TigValidation4Dot1;
 import org.icann.rdapconformance.validator.workflow.profile.tig_section.general.TigValidation7Dot1And7Dot2;
 import org.icann.rdapconformance.validator.workflow.profile.tig_section.registry.TigValidation1Dot11Dot1;
@@ -162,14 +151,6 @@ public class RDAPValidator implements ValidatorWorkflow {
             new ResponseValidationDomainInvalid_2024(queryContext).validate(); // Network calls
         }
 
-        // get all the 2019 profile validations and run them
-        if (queryContext.getConfig().useRdapProfileFeb2019()) {
-            logger.info("Validations for 2019 profile");
-            RDAPProfile rdapProfile = new RDAPProfile(
-                get2019RdapValidations(rdapResponse, validator));
-            rdapProfile.validate();
-        }
-
         // get all the 2024 profile validations and run them
         if (queryContext.getConfig().useRdapProfileFeb2024()) {
             logger.info("Validations for 2024 profile");
@@ -224,7 +205,6 @@ public class RDAPValidator implements ValidatorWorkflow {
         List<ProfileValidation> validations = new ArrayList<>();
 
         // All validations in original order
-        // From 2019 profile validations
         validations.add(new TigValidation3Dot2(queryContext));
         validations.add(new TigValidation4Dot1(queryContext));
         validations.add(new TigValidation7Dot1And7Dot2(queryContext));
@@ -300,69 +280,6 @@ public class RDAPValidator implements ValidatorWorkflow {
             validations.add(new TigValidation1Dot11Dot1(queryContext)); // URL-based validation
             validations.add(new TigValidation1Dot5_2024(queryContext)); // SSL Network connection
             validations.add(new ResponseValidationTestInvalidRedirect_2024(queryContext)); // Network connection
-        }
-
-        return validations;
-    }
-
-
-    private List<ProfileValidation> get2019RdapValidations(HttpResponse<String> rdapResponse, SchemaValidator validator) {
-        // Extract commonly used values from queryContext for convenience
-        RDAPValidatorConfiguration config = queryContext.getConfig();
-        List<ProfileValidation> validations = new ArrayList<>();
-
-        // All validations in original order
-        validations.add(new TigValidation1Dot14(queryContext));
-        validations.add(new TigValidation3Dot2(queryContext));
-        validations.add(new TigValidation3Dot3And3Dot4(queryContext));
-        validations.add(new TigValidation4Dot1(queryContext));
-        validations.add(new TigValidation7Dot1And7Dot2(queryContext));
-        validations.add(new ResponseValidation1Dot2Dot2(queryContext));
-        validations.add(new ResponseValidation1Dot3(queryContext));
-        validations.add(new ResponseValidation1Dot4(queryContext));
-        validations.add(new ResponseValidationLastUpdateEvent(queryContext));
-        validations.add(new ResponseValidation2Dot1(queryContext));
-        validations.add(new ResponseValidation2Dot2(queryContext));
-        validations.add(new ResponseValidation2Dot3Dot1Dot1(queryContext));
-
-        // Only run this validation if it's a gTLD registry
-        if(config.isGtldRegistry()) {
-            validations.add(new ResponseValidation2Dot3Dot1Dot2(queryContext));
-        }
-
-        validations.add(new ResponseValidationNoticesIncluded(queryContext));
-        validations.add(new ResponseValidation2Dot6Dot3(queryContext));
-        validations.add(new ResponseValidation2Dot11(queryContext));
-        validations.add(new ResponseValidation2Dot10(queryContext));
-        validations.add(new ResponseValidationRFC5731(queryContext));
-        validations.add(new ResponseValidationRFC3915(queryContext));
-        validations.add(new ResponseValidation2Dot6Dot1(queryContext));
-        validations.add(new ResponseValidation2Dot9Dot1And2Dot9Dot2(queryContext));
-        validations.add(new ResponseValidation2Dot4Dot1(queryContext));
-        validations.add(new ResponseValidation2Dot4Dot2And2Dot4Dot3(queryContext));
-        validations.add(new ResponseValidation2Dot4Dot5(queryContext));
-        validations.add(new ResponseValidation2Dot7Dot1DotXAndRelated1(queryContext));
-        validations.add(new ResponseValidation2Dot7Dot1DotXAndRelated2(queryContext));
-        validations.add(new ResponseValidation2Dot7Dot1DotXAndRelated3And4(queryContext));
-        validations.add(new ResponseValidation2Dot7Dot1DotXAndRelated5(queryContext));
-        validations.add(new ResponseValidation2Dot7Dot1DotXAndRelated6(queryContext));
-        validations.add(new ResponseValidation2Dot7Dot5Dot2(queryContext));
-        validations.add(new ResponseValidation2Dot7Dot5Dot3(queryContext));
-        validations.add(new ResponseValidation3Dot1(queryContext));
-        validations.add(new ResponseValidation3Dot2(queryContext));
-        validations.add(new ResponseNameserverStatusValidation(queryContext));
-        validations.add(new ResponseValidation4Dot1Handle(queryContext));
-        validations.add(new ResponseValidation4Dot1Query(queryContext));
-        validations.add(new ResponseValidation4Dot3(queryContext));
-
-        // Network-dependent validations
-        if (config.isNetworkEnabled()) {
-            validations.add(new TigValidation1Dot3(queryContext)); // SSL context
-            validations.add(new TigValidation1Dot6(queryContext)); // HTTP head request
-            validations.add(new TigValidation1Dot13(queryContext)); // reads HTTP headers
-            validations.add(new TigValidation1Dot2(queryContext)); // SSL Network connection
-            validations.add(new TigValidation1Dot8(queryContext)); // DNS queries
-            validations.add(new TigValidation1Dot11Dot1(queryContext)); // URL-based validation
         }
 
         return validations;

--- a/validator/src/test/java/org/icann/rdapconformance/validator/configuration/ConfigurationFileParserImplTest.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/configuration/ConfigurationFileParserImplTest.java
@@ -38,7 +38,7 @@ public class ConfigurationFileParserImplTest {
         List.of(new DefinitionWarning(-2186, "This only applies for a few gTLDs.")),
         List.of(-2323, -2345, -2346),
         List.of("This is a configuration definition for a legacy gTLD.", "Developed by ICANN."),
-            false, false, false, false, false);
+            false, false, false, false);
 
     ConfigurationFile config = configParser.parse(new ByteArrayInputStream(configStr.getBytes()));
 
@@ -94,7 +94,7 @@ public class ConfigurationFileParserImplTest {
 
     ConfigurationFile expectedConfig = new ConfigurationFile("gTLD Profile Version 1.0",
         null, null, null, null, false,
-            false, false, false, false);
+            false, false, false);
 
     ConfigurationFile config = configParser.parse(new ByteArrayInputStream(configStr.getBytes()));
 

--- a/validator/src/test/java/org/icann/rdapconformance/validator/configuration/ConfigurationFileTest.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/configuration/ConfigurationFileTest.java
@@ -17,7 +17,7 @@ public class ConfigurationFileTest {
     public void testConstructor_MinimalRequiredFields() {
         ConfigurationFile config = new ConfigurationFile(
             "Test Profile 1.0", null, null, null, null,
-            false, false, false, false, false);
+            false, false, false, false);
         
         assertThat(config.getDefinitionIdentifier()).isEqualTo("Test Profile 1.0");
         assertThat(config.getDefinitionIgnore()).isEmpty();
@@ -25,7 +25,6 @@ public class ConfigurationFileTest {
         assertThat(config.isGtldRegistrar()).isFalse();
         assertThat(config.isGtldRegistry()).isFalse();
         assertThat(config.isThinRegistry()).isFalse();
-        assertThat(config.isRdapProfileFebruary2019()).isFalse();
         assertThat(config.isRdapProfileFebruary2024()).isFalse();
     }
     
@@ -44,7 +43,7 @@ public class ConfigurationFileTest {
         
         ConfigurationFile config = new ConfigurationFile(
             "Full Test Profile 1.0", errors, warnings, ignores, notes,
-            true, false, true, false, true);
+            true, false, true, true);
         
         assertThat(config.getDefinitionIdentifier()).isEqualTo("Full Test Profile 1.0");
         assertThat(config.getDefinitionIgnore()).containsExactly(3001, 3002, 3003);
@@ -52,7 +51,6 @@ public class ConfigurationFileTest {
         assertThat(config.isGtldRegistrar()).isTrue();
         assertThat(config.isGtldRegistry()).isFalse();
         assertThat(config.isThinRegistry()).isTrue();
-        assertThat(config.isRdapProfileFebruary2019()).isFalse();
         assertThat(config.isRdapProfileFebruary2024()).isTrue();
     }
     
@@ -65,7 +63,7 @@ public class ConfigurationFileTest {
         
         ConfigurationFile config = new ConfigurationFile(
             "Error Test Profile", errors, null, null, null,
-            false, false, false, false, false);
+            false, false, false, false);
         
         assertThat(config.isError(1001)).isTrue();
         assertThat(config.isError(1002)).isTrue();
@@ -82,7 +80,7 @@ public class ConfigurationFileTest {
         
         ConfigurationFile config = new ConfigurationFile(
             "Warning Test Profile", null, warnings, null, null,
-            false, false, false, false, false);
+            false, false, false, false);
         
         assertThat(config.isWarning(2001)).isTrue();
         assertThat(config.isWarning(2002)).isTrue();
@@ -99,7 +97,7 @@ public class ConfigurationFileTest {
         
         ConfigurationFile config = new ConfigurationFile(
             "Alert Notes Test", errors, null, null, null,
-            false, false, false, false, false);
+            false, false, false, false);
         
         assertThat(config.getAlertNotes(1001)).isEqualTo("Specific error message");
         assertThat(config.getAlertNotes(1002)).isEqualTo("Another error message");
@@ -115,7 +113,7 @@ public class ConfigurationFileTest {
         
         ConfigurationFile config = new ConfigurationFile(
             "Alert Notes Test", null, warnings, null, null,
-            false, false, false, false, false);
+            false, false, false, false);
         
         assertThat(config.getAlertNotes(2001)).isEqualTo("Specific warning message");
         assertThat(config.getAlertNotes(2002)).isEqualTo("Another warning message");
@@ -126,7 +124,7 @@ public class ConfigurationFileTest {
     public void testGetAlertNotes_NonExistentCode() {
         ConfigurationFile config = new ConfigurationFile(
             "Empty Alert Test", null, null, null, null,
-            false, false, false, false, false);
+            false, false, false, false);
         
         assertThat(config.getAlertNotes(9999)).isEmpty();
     }
@@ -135,7 +133,7 @@ public class ConfigurationFileTest {
     public void testEmptyListIfNull_NullLists() {
         ConfigurationFile config = new ConfigurationFile(
             "Null Lists Test", null, null, null, null,
-            false, false, false, false, false);
+            false, false, false, false);
         
         assertThat(config.getDefinitionIgnore()).isNotNull().isEmpty();
         assertThat(config.getDefinitionNotes()).isNotNull().isEmpty();
@@ -146,7 +144,7 @@ public class ConfigurationFileTest {
         ConfigurationFile config = new ConfigurationFile(
             "Empty Lists Test", Collections.emptyList(), Collections.emptyList(), 
             Collections.emptyList(), Collections.emptyList(),
-            false, false, false, false, false);
+            false, false, false, false);
         
         assertThat(config.getDefinitionIgnore()).isEmpty();
         assertThat(config.getDefinitionNotes()).isEmpty();
@@ -156,7 +154,7 @@ public class ConfigurationFileTest {
     public void testErrorAndWarningCodes_EmptyWhenNull() {
         ConfigurationFile config = new ConfigurationFile(
             "Empty Codes Test", null, null, null, null,
-            false, false, false, false, false);
+            false, false, false, false);
         
         assertThat(config.isError(1001)).isFalse();
         assertThat(config.isWarning(2001)).isFalse();
@@ -178,7 +176,6 @@ public class ConfigurationFileTest {
             + "\"gtldRegistrar\": true,"
             + "\"gtldRegistry\": false,"
             + "\"thinRegistry\": false,"
-            + "\"rdapProfileFebruary2019\": true,"
             + "\"rdapProfileFebruary2024\": false"
             + "}";
         
@@ -192,7 +189,6 @@ public class ConfigurationFileTest {
         assertThat(config.getDefinitionNotes()).containsExactly("JSON Note 1", "JSON Note 2");
         assertThat(config.isGtldRegistrar()).isTrue();
         assertThat(config.isGtldRegistry()).isFalse();
-        assertThat(config.isRdapProfileFebruary2019()).isTrue();
         assertThat(config.isRdapProfileFebruary2024()).isFalse();
     }
     
@@ -200,22 +196,20 @@ public class ConfigurationFileTest {
     public void testBooleanFlags_AllCombinations() {
         ConfigurationFile config1 = new ConfigurationFile(
             "Flags Test 1", null, null, null, null,
-            true, true, true, true, true);
+            true, true, true, true);
         
         assertThat(config1.isGtldRegistrar()).isTrue();
         assertThat(config1.isGtldRegistry()).isTrue();
         assertThat(config1.isThinRegistry()).isTrue();
-        assertThat(config1.isRdapProfileFebruary2019()).isTrue();
         assertThat(config1.isRdapProfileFebruary2024()).isTrue();
         
         ConfigurationFile config2 = new ConfigurationFile(
             "Flags Test 2", null, null, null, null,
-            false, false, false, false, false);
+            false, false, false, false);
         
         assertThat(config2.isGtldRegistrar()).isFalse();
         assertThat(config2.isGtldRegistry()).isFalse();
         assertThat(config2.isThinRegistry()).isFalse();
-        assertThat(config2.isRdapProfileFebruary2019()).isFalse();
         assertThat(config2.isRdapProfileFebruary2024()).isFalse();
     }
 }

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidationResultFileTest.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidationResultFileTest.java
@@ -9,7 +9,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -34,7 +33,6 @@ import org.icann.rdapconformance.validator.configuration.ConfigurationFile;
 import org.icann.rdapconformance.validator.configuration.RDAPValidatorConfiguration;
 import org.icann.rdapconformance.validator.workflow.FileSystem;
 import org.json.JSONObject;
-import org.mockito.MockedStatic;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -142,14 +140,6 @@ public class RDAPValidationResultFileTest {
 
         verify(fileSystem).write(any(), contains("\"buildDate\": \"" + BuildInfo.getBuildDate() + "\""));
     }
-
-
-
-  @Test
-  public void testProfileFebruary2019() throws IOException {
-    file.build();
-    verify(fileSystem).write(any(), contains("\"rdapProfileFebruary2019\": false"));
-  }
 
   @Test
   public void testProfileFebruary2024() throws IOException {

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidatorTest.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidatorTest.java
@@ -43,7 +43,7 @@ public class RDAPValidatorTest {
     validator = new RDAPValidator(QueryContext.create(config, datasetService, query));
     doReturn(true).when(processor).check(eq(datasetService), any(QueryContext.class));
     doReturn(true).when(datasetService).download(anyBoolean());
-    doReturn(new ConfigurationFile("Test", null, null, null, null, false, false, false, false, false))
+    doReturn(new ConfigurationFile("Test", null, null, null, null, false, false, false, false))
         .when(configParser).parse(any());
   }
 
@@ -119,7 +119,7 @@ public class RDAPValidatorTest {
     doReturn(true).when(queryTypeProcessor).check(eq(datasetService), any(QueryContext.class));
     doReturn(true).when(datasetService).download(anyBoolean());
     doReturn(new ConfigurationFile(
-            "Test", null, null, null, null, false, false, false, false, false))
+            "Test", null, null, null, null, false, false, false, false))
             .when(configParser).parse(any());
     doReturn(false).when(query).run();
     doReturn(null).when(query).getErrorStatus();
@@ -148,7 +148,7 @@ public void testValidate_DomainQueryForTestInvalidWithHttpOK_LogsInfo() throws I
     doReturn(URI.create("https://example.com")).when(config).getUri();
     doReturn(true).when(datasetService).download(anyBoolean());
     doReturn(new ConfigurationFile(
-        "definitionIdentifier", null, null, null, null, false, false, false, false, false))
+        "definitionIdentifier", null, null, null, null, false, false, false, false))
         .when(configParser).parse(any());
     doReturn(true).when(query).run();
     doReturn("test.invalid").when(query).getData();
@@ -176,7 +176,6 @@ public void testValidate_DomainQueryForTestInvalidWithHttpOK_LogsInfo() throws I
 
         doReturn(URI.create("https://example.com/rdap/domain/test.example")).when(config).getUri();
         doReturn(true).when(config).check();
-        doReturn(false).when(config).useRdapProfileFeb2019();
         doReturn(false).when(config).useRdapProfileFeb2024();
         doReturn(false).when(config).isAdditionalConformanceQueries();
         doReturn(false).when(config).isNetworkEnabled();


### PR DESCRIPTION
## Required Information

### PR Description (Include comprehensive description)

#### Summary of changes:
feat!: remove RDAP Profile February 2019 support

Remove all references to the 2019 RDAP profile option across the codebase
as it is no longer supported. The February 2024 profile is now the only
supported profile.

Changes include:
- Remove --use-rdap-profile-february-2019 CLI option from RdapConformanceTool
- Remove useRdapProfileFeb2019() from RDAPValidatorConfiguration interface
- Remove rdapProfileFebruary2019 field and deserialization from ConfigurationFile
- Remove get2019RdapValidations() method and its execution block from RDAPValidator
- Remove rdapProfileFebruary2019 field from RDAPValidationResultFile output
- Simplify ConnectionTracker profile check to use only 2024 profile flag
- Remove useRdapProfileFeb2019 from RdapWebValidator and its configuration
- Remove related tests and test assertions referencing the 2019 profile
- Update tool/README.md and doc/process_flow.md to remove 2019 profile docs

BREAKING CHANGE: --use-rdap-profile-february-2019 CLI flag is no longer
accepted. Callers must migrate to --use-rdap-profile-february-2024.
#### Problem/feature addressed:
The gTLD RDAP profile is now obsolete. Please remove the checkmark option from the web front-end.

#### Relevant screenshots/diagrams:
<img width="634" height="505" alt="image" src="https://github.com/user-attachments/assets/137d15f2-88e2-4732-988e-a6d3838258fd" />

#### Links to relevant issues/tasks:
https://icann-jira.atlassian.net/browse/RCT-491
### Branch Name

- [x] Does the branch name follow the Branch Naming Convention?

#### If not, explain why:

### Code Changes

- [x] Are code changes adhering to coding standards and practices?

#### If not, explain why:

### Commit Messages

- [ ] Do commit messages follow [Conventional Commits guidelines](https://wecann.icann.org/docs/DOC-40501)?
- [x] Are they clear, concise, and informative using imperative language?

#### If not, explain why:

### Tests and Test Coverage

- [x] Are changes covered by appropriate tests?
- [ ] Were unit tests, integration tests, and end-to-end tests run?
- [ ] Was the test coverage maintained or improved? Please include before/after results.

#### If not, explain why:

### Bug Fixes and Tests

- [ ] For bug fixes, are there:
    - [ ] Tests that reproduce the bug before the changes?
    - [ ] Tests that demonstrate the bug is resolved after the changes?

#### If not, explain why:

### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Documentation

- [ ] Are there updates to documentation that need to be made?
- [x] Are they included or linked in the PR description?

#### If not, explain why:

### PR Size

- [x] Is the PR small and focused on one logical change?

#### If not, explain why:

---