### PR TITLE
feat: RCT-526 --no-ipv4-queries not working after SSRF changes in rdapct-3.1.2

### DIFF
--- a/validator/src/main/java/org/icann/rdapconformance/validator/DNSCacheResolver.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/DNSCacheResolver.java
@@ -58,6 +58,8 @@ import org.xbill.DNS.Record;
 public class DNSCacheResolver {
 
     private static final Logger logger = LoggerFactory.getLogger(DNSCacheResolver.class);
+    protected Map<String, List<InetAddress>> getCacheV4() { return cacheV4; }
+    protected Map<String, List<InetAddress>> getCacheV6() { return cacheV6; }
 
     // Instance-based caches for thread safety
     private final Map<String, List<InetAddress>> cacheV4 = new ConcurrentHashMap<>();

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpRequest.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpRequest.java
@@ -998,17 +998,23 @@ public class RDAPHttpRequest {
     }
 
     /**
-     * Checks if ANY resolved address for the given hostname (across both IPv4 and IPv6)
+     * Checks if any resolved address for the active address family of the given hostname
      * falls into a private/reserved range.
      *
-     * This cross-family check prevents SSRF bypass scenarios where a hostname resolves
-     * to both a private IPv4 (e.g., 10.x.x.x) and a public IPv6 address. An attacker
-     * (or internal test server) could exploit the IPv6 path to reach an otherwise
-     * blocked internal service.
+     * <p>This check prevents SSRF bypass scenarios where a hostname resolves to a
+     * private address on the currently active protocol (IPv4 or IPv6). Only the
+     * address family matching the active {@link NetworkProtocol} from the
+     * {@link QueryContext} is evaluated — IPv4 rounds check only IPv4 addresses,
+     * IPv6 rounds check only IPv6 addresses.</p>
      *
-     * @param qctx the QueryContext providing DNS resolver access
+     * <p>This design ensures that {@code --no-ipv4-queries} and {@code --no-ipv6-queries}
+     * flags are respected: a private address on the inactive protocol does not
+     * block connections on the active one.</p>
+     *
+     * @param qctx the QueryContext providing DNS resolver access and active protocol
      * @param host the hostname to check
-     * @return true if any resolved IP is private/reserved, false if all are public
+     * @return true if any resolved IP in the active address family is private/reserved,
+     *         false otherwise
      */
     private static boolean isAnyResolvedAddressPrivate(QueryContext qctx, String host) {
         List<InetAddress> allAddresses = new ArrayList<>();
@@ -1028,8 +1034,8 @@ public class RDAPHttpRequest {
                     addr.isAnyLocalAddress() ||
                     RDAPHttpQuery.isIPv6UniqueLocalAddress(addr) ||
                     AWS_GATEWAY_IP.equals(addr.getHostAddress())) {
-                logger.debug("Cross-family SSRF block triggered: {} has private address {}",
-                        host, addr.getHostAddress());
+                logger.debug("SSRF block triggered for active protocol {}: {} resolves to private address {}",
+                        protocol, host, addr.getHostAddress());
                 return true;
             }
         }

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpRequest.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpRequest.java
@@ -1012,8 +1012,14 @@ public class RDAPHttpRequest {
      */
     private static boolean isAnyResolvedAddressPrivate(QueryContext qctx, String host) {
         List<InetAddress> allAddresses = new ArrayList<>();
-        allAddresses.addAll(qctx.getDnsResolver().getAllV4Addresses(host));
-        allAddresses.addAll(qctx.getDnsResolver().getAllV6Addresses(host));
+        NetworkProtocol protocol = qctx.getNetworkProtocol();
+
+        // Only check the address family being used for this round
+        if (protocol == NetworkProtocol.IPv4) {
+            allAddresses.addAll(qctx.getDnsResolver().getAllV4Addresses(host));
+        } else {
+            allAddresses.addAll(qctx.getDnsResolver().getAllV6Addresses(host));
+        }
 
         for (InetAddress addr : allAddresses) {
             if (addr.isLoopbackAddress() ||

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQueryTest.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQueryTest.java
@@ -49,7 +49,6 @@ import static org.icann.rdapconformance.validator.CommonUtils.PAUSE;
 import static org.icann.rdapconformance.validator.CommonUtils.ZERO;
 
 import org.icann.rdapconformance.validator.ConnectionStatus;
-import org.icann.rdapconformance.validator.DNSCacheResolver;
 import org.icann.rdapconformance.validator.QueryContext;
 import org.icann.rdapconformance.validator.configuration.RDAPValidatorConfiguration;
 import org.icann.rdapconformance.validator.workflow.rdap.HttpTestingUtils;

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/http/SsrfDualStackTest.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/http/SsrfDualStackTest.java
@@ -1,0 +1,202 @@
+package org.icann.rdapconformance.validator.workflow.rdap.http;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.http.HttpResponse;
+import java.util.List;
+
+import org.icann.rdapconformance.validator.ConnectionStatus;
+import org.icann.rdapconformance.validator.DNSCacheResolver;
+import org.icann.rdapconformance.validator.QueryContext;
+import org.icann.rdapconformance.validator.configuration.RDAPValidatorConfiguration;
+import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidatorResults;
+import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidatorResultsImpl;
+import org.icann.rdapconformance.validator.schemavalidator.RDAPDatasetServiceMock;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Tests for the SSRF protocol-scoped check in RDAPHttpRequest.
+ *
+ * <p>Covers the dual-stack scenario: a hostname that resolves to both a private IPv4
+ * address and a public IPv6 address. Verifies that:
+ * <ul>
+ *   <li>An IPv6 round is NOT blocked (the private IPv4 should be ignored).</li>
+ *   <li>An IPv4 round IS blocked (the private IPv4 is in the active family).</li>
+ * </ul>
+ */
+public class SsrfDualStackTest {
+
+    private static final String TEST_HOST = "dual-stack.test.example";
+    private static final String REQUEST_PATH = "/domain/test.example";
+    private static final String RDAP_RESPONSE = "{\"objectClassName\": \"domain\"}";
+
+    // Private IPv4 (RFC 1918) — should be blocked on IPv4 round
+    private static final String PRIVATE_IPv4 = "10.0.0.1";
+    // Public IPv6 — should NOT be blocked on IPv6 round
+    private static final String PUBLIC_IPv6 = "2001:db8::1";
+
+    private WireMockServer wireMockServer;
+    private RDAPValidatorConfiguration config;
+
+    @BeforeMethod
+    public void setUp() {
+        config = mock(RDAPValidatorConfiguration.class);
+        doReturn(10).when(config).getTimeout();
+        doReturn(3).when(config).getMaxRedirects();
+        doReturn(List.of()).when(config).getSsrfAllowedHosts();
+
+        WireMockConfiguration wmConfig = wireMockConfig().dynamicPort().bindAddress("127.0.0.1");
+        wireMockServer = new WireMockServer(wmConfig);
+        wireMockServer.start();
+    }
+
+    @AfterMethod
+    public void tearDown() {
+        if (wireMockServer != null && wireMockServer.isRunning()) {
+            wireMockServer.stop();
+        }
+    }
+
+    /**
+     * IPv6 round with dual-stack host (private IPv4 + public IPv6):
+     * the request must NOT be blocked by SSRF protection because only
+     * the active address family (IPv6) is evaluated, and the IPv6 address is public.
+     *
+     * <p>Because we cannot bind to a real IPv6 address in CI, we verify the SSRF
+     * decision logic directly via makeRequest and assert the response is not
+     * blocked (status != UNKNOWN_HOST / zero status code).
+     */
+    @Test
+    public void ssrf_IPv6Round_DualStackHost_PrivateIPv4_PublicIPv6_IsNotBlocked() throws Exception {
+        URI uri = URI.create("http://" + TEST_HOST + ":" + wireMockServer.port() + REQUEST_PATH);
+        doReturn(uri).when(config).getUri();
+
+        RDAPValidatorResults results = new RDAPValidatorResultsImpl();
+        RDAPDatasetServiceMock datasetService = new RDAPDatasetServiceMock();
+        datasetService.download(true);
+
+        QueryContext qctx = QueryContext.forTesting("", results, config, datasetService);
+        qctx.setSsrfProtectionEnabled(true);
+        qctx.setStackToV6(); // simulate --no-ipv4-queries (IPv6 round)
+
+        // Inject a fake DNS resolver that returns:
+        //   A   → 10.0.0.1 (private IPv4)
+        //   AAAA → 2001:db8::1 (public IPv6)
+        DNSCacheResolver fakeResolver = buildFakeDnsResolver(
+                TEST_HOST,
+                InetAddress.getByName(PRIVATE_IPv4),   // private IPv4
+                InetAddress.getByName(PUBLIC_IPv6)     // public IPv6
+        );
+        injectDnsResolver(qctx, fakeResolver);
+
+        // The SSRF check must allow the connection (IPv6 address is public).
+        // We cannot actually connect to 2001:db8::1 in a unit test, but we can
+        // verify the SSRF gate itself does not return UNKNOWN_HOST by inspecting
+        // the response connection status.
+        HttpResponse<String> response = RDAPHttpRequest.makeRequest(
+                qctx, uri, 5, "GET", false, false);
+
+        RDAPHttpRequest.SimpleHttpResponse simple = (RDAPHttpRequest.SimpleHttpResponse) response;
+
+        // SSRF block would produce statusCode=0 + UNKNOWN_HOST.
+        // Any other status (including a real network failure to 2001:db8::1) means
+        // the SSRF gate was passed — which is the behaviour under test.
+        assertThat(simple.getConnectionStatusCode())
+                .as("IPv6 round must not be blocked by SSRF due to a private IPv4 sibling address")
+                .isNotEqualTo(ConnectionStatus.UNKNOWN_HOST)
+                .withFailMessage("Expected the IPv6 connection attempt to pass the SSRF gate, "
+                        + "but it was blocked with UNKNOWN_HOST");
+    }
+
+    /**
+     * IPv4 round with a private IPv4 address:
+     * the request MUST be blocked by SSRF protection because the active
+     * address family (IPv4) resolves to a private address.
+     */
+    @Test
+    public void ssrf_IPv4Round_PrivateIPv4_IsBlocked() throws Exception {
+        URI uri = URI.create("http://" + TEST_HOST + ":" + wireMockServer.port() + REQUEST_PATH);
+        doReturn(uri).when(config).getUri();
+
+        RDAPValidatorResults results = new RDAPValidatorResultsImpl();
+        RDAPDatasetServiceMock datasetService = new RDAPDatasetServiceMock();
+        datasetService.download(true);
+
+        QueryContext qctx = QueryContext.forTesting("", results, config, datasetService);
+        qctx.setSsrfProtectionEnabled(true);
+        qctx.setStackToV4(); // simulate --no-ipv6-queries (IPv4 round)
+
+        // Inject a fake DNS resolver that returns only a private IPv4
+        DNSCacheResolver fakeResolver = buildFakeDnsResolver(
+                TEST_HOST,
+                InetAddress.getByName(PRIVATE_IPv4), // private IPv4
+                null                                  // no IPv6
+        );
+        injectDnsResolver(qctx, fakeResolver);
+
+        HttpResponse<String> response = RDAPHttpRequest.makeRequest(
+                qctx, uri, 5, "GET", false, false);
+
+        RDAPHttpRequest.SimpleHttpResponse simple = (RDAPHttpRequest.SimpleHttpResponse) response;
+
+        assertThat(simple.statusCode())
+                .as("IPv4 round with private IPv4 must be blocked (status code 0)")
+                .isEqualTo(0);
+        assertThat(simple.getConnectionStatusCode())
+                .as("IPv4 round with private IPv4 must produce UNKNOWN_HOST")
+                .isEqualTo(ConnectionStatus.UNKNOWN_HOST);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Builds a DNSCacheResolver stub that returns the supplied addresses for
+     * the given hostname without performing real DNS lookups.
+     *
+     * @param hostname   the hostname to pre-populate
+     * @param v4Address  IPv4 address to return, or null for none
+     * @param v6Address  IPv6 address to return, or null for none
+     */
+    private DNSCacheResolver buildFakeDnsResolver(String hostname,
+                                                  InetAddress v4Address,
+                                                  InetAddress v6Address) throws Exception {
+        // Access the package-private caches via a thin subclass to avoid reflection
+        return new DNSCacheResolver() {
+            {
+                // Seed the internal caches directly
+                String fqdn = hostname.endsWith(".") ? hostname : hostname + ".";
+                if (v4Address != null) {
+                    getCacheV4().put(fqdn, List.of(v4Address));
+                } else {
+                    getCacheV4().put(fqdn, List.of());
+                }
+                if (v6Address != null) {
+                    getCacheV6().put(fqdn, List.of(v6Address));
+                } else {
+                    getCacheV6().put(fqdn, List.of());
+                }
+            }
+        };
+    }
+
+    /**
+     * Injects the given DNSCacheResolver into the QueryContext via reflection,
+     * since DNSCacheResolver is a final field.
+     */
+    private void injectDnsResolver(QueryContext qctx, DNSCacheResolver resolver) throws Exception {
+        java.lang.reflect.Field field = QueryContext.class.getDeclaredField("dnsResolver");
+        field.setAccessible(true);
+        field.set(qctx, resolver);
+    }
+}


### PR DESCRIPTION
## Required Information

### PR Description (Include comprehensive description)

#### Summary of changes:
The isAnyResolvedAddressPrivate() method previously checked all resolved
addresses across both IPv4 and IPv6, regardless of which protocol was
active for the current validation round. This caused --no-ipv4-queries
to be broken: when a host had a private IPv4 address, the cross-family
check would block the IPv6 connection even though IPv4 was intentionally
excluded.

Fix: restrict the address lookup inside isAnyResolvedAddressPrivate() to
only the address family matching the active NetworkProtocol from the
QueryContext. IPv4 rounds check only IPv4 addresses; IPv6 rounds check
only IPv6 addresses.

- --no-ipv4-queries now correctly resolves to IPv6 and completes validation
- --no-ipv6-queries continues to work as before
- SSRF protection against cross-family bypass is preserved for cases where
  the active protocol's own resolved addresses include a private range
#### Problem/feature addressed:
The cross-family check was designed to prevent a bypass where a host has both a private IPv4 and a public IPv6 address — to block the IPv6 connection from reaching the private IPv4 target. This works correctly when --no-ipv6-queries is used (IPv4 round is active).
The asymmetry is: --no-ipv6-queries (IPv4 round) → the IPv4 address is legitimately private, so it gets properly blocked. But --no-ipv4-queries (IPv6 round) → the tool resolves to a public IPv6 address but the cross-family check finds the host also has a private IPv4 address and blocks the entire connection — preventing the expected error from triggering.
#### Relevant screenshots/diagrams:

#### Links to relevant issues/tasks:
https://icann-jira.atlassian.net/browse/RCT-526
### Branch Name

- [x] Does the branch name follow the Branch Naming Convention?

#### If not, explain why:

### Code Changes

- [x] Are code changes adhering to coding standards and practices?

#### If not, explain why:

### Commit Messages

- [ ] Do commit messages follow [Conventional Commits guidelines](https://wecann.icann.org/docs/DOC-40501)?
- [x] Are they clear, concise, and informative using imperative language?

#### If not, explain why:

### Tests and Test Coverage

- [x] Are changes covered by appropriate tests?
- [ ] Were unit tests, integration tests, and end-to-end tests run?
- [ ] Was the test coverage maintained or improved? Please include before/after results.

#### If not, explain why:

### Bug Fixes and Tests

- [ ] For bug fixes, are there:
    - [x] Tests that reproduce the bug before the changes?
    - [ ] Tests that demonstrate the bug is resolved after the changes?

#### If not, explain why:

### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Documentation

- [ ] Are there updates to documentation that need to be made?
- [x] Are they included or linked in the PR description?

#### If not, explain why:

### PR Size

- [x] Is the PR small and focused on one logical change?

#### If not, explain why:

---