### PR TITLE
feat: RCT-505-65705  jsonpath is empty set

### DIFF
--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/entity/ResponseValidationTechHandle_2024.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/entity/ResponseValidationTechHandle_2024.java
@@ -172,6 +172,17 @@ public final class ResponseValidationTechHandle_2024 extends ProfileJsonValidati
             return false;
         }
 
+        // -65705: valid JSONPath expression must evaluate to an empty set
+        var prePathPointer = getPointerFromJPath(prePath);
+        if (prePathPointer != null && !prePathPointer.isEmpty()) {
+            results.add(RDAPValidationResult.builder()
+                    .code(-65705)
+                    .value(redactedTechId.toString())
+                    .message("jsonpath must evaluate to a zero set for redaction removal of Registry Tech ID.")
+                    .build(queryContext));
+            return false;
+        }
+
         return true;
     }
 

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/entity/ResponseValidationTechHandle_2024Test.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/entity/ResponseValidationTechHandle_2024Test.java
@@ -285,6 +285,84 @@ public class ResponseValidationTechHandle_2024Test extends ProfileJsonValidation
         validate();
     }
 
+    /**
+     * Test -65705: no handle, redaction present, prePath is valid JSONPath but evaluates
+     * to a non-empty set (field still exists in the response) -> -65705.
+     */
+    @Test
+    public void ResponseValidationTechHandle_2024_65705() {
+        JSONObject techEntity = jsonObject.getJSONArray("entities").getJSONObject(1);
+        techEntity.remove("handle"); // no handle
+
+        JSONObject redactedTechId = new JSONObject();
+        JSONObject name = new JSONObject();
+        name.put("type", "Registry Tech ID");
+        redactedTechId.put("name", name);
+        redactedTechId.put("method", "removal");
+        redactedTechId.put("pathLang", "jsonpath");
+        // This JSONPath evaluates to a non-empty set because "objectClassName" exists in entities[1]
+        redactedTechId.put("prePath", "$.entities[1].objectClassName");
+        redactedTechId.put("reason", new JSONObject().put("description", "Server policy"));
+        jsonObject.getJSONArray("redacted").put(redactedTechId);
+
+        int insertedIndex = jsonObject.getJSONArray("redacted").length() - 1;
+        String expectedValue = jsonObject.getJSONArray("redacted")
+                .getJSONObject(insertedIndex)
+                .toString();
+
+        validate(-65705, expectedValue,
+                "jsonpath must evaluate to a zero set for redaction removal of Registry Tech ID.");
+    }
+
+    /**
+     * No handle, redaction present, valid prePath evaluates to empty set -> no -65705.
+     */
+    @Test
+    public void testNoHandleRedactionPrePathEmptySet_passes() {
+        JSONObject techEntity = jsonObject.getJSONArray("entities").getJSONObject(1);
+        techEntity.remove("handle"); // no handle — field is absent, path evaluates to empty set
+
+        JSONObject redactedTechId = new JSONObject();
+        JSONObject name = new JSONObject();
+        name.put("type", "Registry Tech ID");
+        redactedTechId.put("name", name);
+        redactedTechId.put("method", "removal");
+        redactedTechId.put("pathLang", "jsonpath");
+        // handle was removed above, so this path evaluates to empty set
+        redactedTechId.put("prePath", "$.entities[?(@.roles[0]=='technical')].handle");
+        redactedTechId.put("reason", new JSONObject().put("description", "Server policy"));
+        jsonObject.getJSONArray("redacted").put(redactedTechId);
+
+        validate();
+    }
+
+    /**
+     * No handle, redaction present, pathLang absent, valid prePath evaluates to non-empty set -> -65705.
+     */
+    @Test
+    public void testNoHandleRedactionNoPathLangPrePathNonEmpty_triggers65705() {
+        JSONObject techEntity = jsonObject.getJSONArray("entities").getJSONObject(1);
+        techEntity.remove("handle");
+
+        JSONObject redactedTechId = new JSONObject();
+        JSONObject name = new JSONObject();
+        name.put("type", "Registry Tech ID");
+        redactedTechId.put("name", name);
+        redactedTechId.put("method", "removal");
+        // no pathLang — spec says absent pathLang also triggers prePath validation
+        redactedTechId.put("prePath", "$.entities[1].objectClassName"); // non-empty set
+        redactedTechId.put("reason", new JSONObject().put("description", "Server policy"));
+        jsonObject.getJSONArray("redacted").put(redactedTechId);
+
+        int insertedIndex = jsonObject.getJSONArray("redacted").length() - 1;
+        String expectedValue = jsonObject.getJSONArray("redacted")
+                .getJSONObject(insertedIndex)
+                .toString();
+
+        validate(-65705, expectedValue,
+                "jsonpath must evaluate to a zero set for redaction removal of Registry Tech ID.");
+    }
+
     // Helper — mirrors the one in ResponseValidationRegistrantHandle_2024Test
     private String getResultValueFromRedactedPointers() {
         JSONArray redacted = jsonObject.getJSONArray("redacted");

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/entity/ResponseValidationTechHandle_2024Test.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/profile/rdap_response/entity/ResponseValidationTechHandle_2024Test.java
@@ -217,9 +217,7 @@ public class ResponseValidationTechHandle_2024Test extends ProfileJsonValidation
                 "jsonpath is invalid for Registry Tech ID");
     }
 
-    /**
-     * No handle, redaction present with pathLang "jsonpath" and valid prePath → no error.
-     */
+    /** * No handle, redaction present with pathLang "jsonpath" and valid prePath -> no error. */
     @Test
     public void testNoHandleRedactionWithValidPrePath_passes() {
         JSONObject techEntity = jsonObject.getJSONArray("entities").getJSONObject(1);
@@ -231,7 +229,8 @@ public class ResponseValidationTechHandle_2024Test extends ProfileJsonValidation
         redactedTechId.put("name", name);
         redactedTechId.put("method", "removal");
         redactedTechId.put("pathLang", "jsonpath");
-        redactedTechId.put("prePath", "$.entities[?(@.roles[0]=='technical')].handle"); // valid JSONPath
+        // reuse the same filter used by the validator — order-independent roles check
+        redactedTechId.put("prePath", "$.entities[?(@.roles contains 'technical')].handle");
         redactedTechId.put("reason", new JSONObject().put("description", "Server policy"));
         jsonObject.getJSONArray("redacted").put(redactedTechId);
 
@@ -300,7 +299,7 @@ public class ResponseValidationTechHandle_2024Test extends ProfileJsonValidation
         redactedTechId.put("name", name);
         redactedTechId.put("method", "removal");
         redactedTechId.put("pathLang", "jsonpath");
-        // This JSONPath evaluates to a non-empty set because "objectClassName" exists in entities[1]
+        // "objectClassName" is always present in entity objects — guaranteed non-empty set
         redactedTechId.put("prePath", "$.entities[1].objectClassName");
         redactedTechId.put("reason", new JSONObject().put("description", "Server policy"));
         jsonObject.getJSONArray("redacted").put(redactedTechId);
@@ -314,13 +313,11 @@ public class ResponseValidationTechHandle_2024Test extends ProfileJsonValidation
                 "jsonpath must evaluate to a zero set for redaction removal of Registry Tech ID.");
     }
 
-    /**
-     * No handle, redaction present, valid prePath evaluates to empty set -> no -65705.
-     */
+    /** * No handle, redaction present, valid prePath evaluates to empty set -> no -65705. */
     @Test
     public void testNoHandleRedactionPrePathEmptySet_passes() {
         JSONObject techEntity = jsonObject.getJSONArray("entities").getJSONObject(1);
-        techEntity.remove("handle"); // no handle — field is absent, path evaluates to empty set
+        techEntity.remove("handle"); // handle removed, so path evaluates to empty set
 
         JSONObject redactedTechId = new JSONObject();
         JSONObject name = new JSONObject();
@@ -328,8 +325,8 @@ public class ResponseValidationTechHandle_2024Test extends ProfileJsonValidation
         redactedTechId.put("name", name);
         redactedTechId.put("method", "removal");
         redactedTechId.put("pathLang", "jsonpath");
-        // handle was removed above, so this path evaluates to empty set
-        redactedTechId.put("prePath", "$.entities[?(@.roles[0]=='technical')].handle");
+        // reuse the same filter used by the validator — order-independent roles check
+        redactedTechId.put("prePath", "$.entities[?(@.roles contains 'technical')].handle");
         redactedTechId.put("reason", new JSONObject().put("description", "Server policy"));
         jsonObject.getJSONArray("redacted").put(redactedTechId);
 


### PR DESCRIPTION
## Required Information

### PR Description (Include comprehensive description)

#### Summary of changes:
Extend ResponseValidationTechHandle_2024 with test case -65705 which
verifies that when a "Registry Tech ID" redaction object is found and
pathLang is absent or "jsonpath", a valid prePath expression must
evaluate to an empty set (zero set), mirroring the -63104 logic for
registrant handles.

Changes:
- Add -65705 check in validatePrePath() after the JSONPath validity
  check: if getPointerFromJPath(prePath) returns a non-empty result,
  emit -65705
- Add ResponseValidationTechHandle_2024_65705: valid prePath pointing
  to an existing field evaluates to non-empty set -> -65705
- Add testNoHandleRedactionPrePathEmptySet_passes: prePath pointing to
  the removed handle evaluates to empty set -> passes
- Add testNoHandleRedactionNoPathLangPrePathNonEmpty_triggers65705:
  pathLang absent + valid prePath evaluating to non-empty set -> -65705
#### Problem/feature addressed:
Test case -65705: With the JSONPath expression from test case -65703, if the pathLang property is either absent or is present as a string of “jsonpath” then verify that the expression evaluates to an empty set.

#### Relevant screenshots/diagrams:

#### Links to relevant issues/tasks:
https://icann-jira.atlassian.net/browse/RCT-505
### Branch Name

- [x] Does the branch name follow the Branch Naming Convention?

#### If not, explain why:

### Code Changes

- [x] Are code changes adhering to coding standards and practices?

#### If not, explain why:

### Commit Messages

- [ ] Do commit messages follow [Conventional Commits guidelines](https://wecann.icann.org/docs/DOC-40501)?
- [x] Are they clear, concise, and informative using imperative language?

#### If not, explain why:

### Tests and Test Coverage

- [x] Are changes covered by appropriate tests?
- [ ] Were unit tests, integration tests, and end-to-end tests run?
- [ ] Was the test coverage maintained or improved? Please include before/after results.

#### If not, explain why:

### Bug Fixes and Tests

- [ ] For bug fixes, are there:
    - [ ] Tests that reproduce the bug before the changes?
    - [ ] Tests that demonstrate the bug is resolved after the changes?

#### If not, explain why:

### Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Documentation

- [ ] Are there updates to documentation that need to be made?
- [x] Are they included or linked in the PR description?

#### If not, explain why:

### PR Size

- [x] Is the PR small and focused on one logical change?

#### If not, explain why:

---