### PR TITLE
bug/RCT-477-bug-handling-IDN-label

### DIFF
--- a/tool/src/main/java/org/icann/rdapconformance/tool/RdapConformanceTool.java
+++ b/tool/src/main/java/org/icann/rdapconformance/tool/RdapConformanceTool.java
@@ -1281,10 +1281,9 @@ public void setShowProgress(boolean showProgress) {
   static class IdnAwareUriConverter implements CommandLine.ITypeConverter<URI> {
     @Override
     public URI convert(String value) throws Exception {
-      // Always normalize IDN domains in the path, even if URI.create succeeds
-      // (e.g., percent-encoded Unicode like nic.%D0%B4%D0%B5%D1%82%D0%B8)
       return normalizeIdnUri(value);
     }
+
 
     private URI normalizeIdnUri(String input) throws java.net.URISyntaxException {
       // Pre-encode non-ASCII characters so java.net.URI can parse the structure
@@ -1359,7 +1358,6 @@ public void setShowProgress(boolean showProgress) {
      * Also handles percent-encoded Unicode by decoding first, then converting.
      */
     static String convertIdnInPath(String path) {
-      // Decode any percent-encoded characters first
       String decodedPath;
       try {
         decodedPath = decode(path, UTF_8);
@@ -1367,21 +1365,55 @@ public void setShowProgress(boolean showProgress) {
         decodedPath = path;
       }
 
-      // Match RDAP path patterns: /domain/{name} or /nameserver/{name}
-      // The domain name is the last segment after /domain/ or /nameserver/
       String[] rdapPrefixes = {"/domain/", "/nameserver/"};
       for (String prefix : rdapPrefixes) {
         int idx = decodedPath.toLowerCase().lastIndexOf(prefix);
         if (idx >= 0) {
           String before = decodedPath.substring(0, idx + prefix.length());
           String domainName = decodedPath.substring(idx + prefix.length());
-          // Convert each label to A-label
+
+          // If mixed labels: percent-encode as-is (don't convert to punycode)
+          // so RDAPHttpQueryTypeProcessor.hasMixedLabels() can detect it after URLDecoding
+          if (hasMixedLabelsInDomain(domainName)) {
+            // percent-encode non-ASCII chars without punycode conversion
+            StringBuilder encoded = new StringBuilder();
+            for (char c : domainName.toCharArray()) {
+              if (c > 0x7F) {
+                for (byte b : String.valueOf(c).getBytes(UTF_8)) {
+                  encoded.append(String.format("%%%02X", b & 0xFF));
+                }
+              } else {
+                encoded.append(c);
+              }
+            }
+            return before + encoded;
+          }
+
           domainName = toASCII(domainName);
           return before + domainName;
         }
       }
 
       return decodedPath;
+    }
+
+    private static boolean hasMixedLabelsInDomain(String domainName) {
+      boolean hasALabel = false;
+      boolean hasULabel = false;
+      for (String label : domainName.split("\\.")) {
+        if (label.toLowerCase().startsWith("xn--")) {
+          hasALabel = true;
+        } else {
+          for (char c : label.toCharArray()) {
+            if (c > 127) {
+              hasULabel = true;
+              break;
+            }
+          }
+        }
+        if (hasALabel && hasULabel) return true;
+      }
+      return false;
     }
   }
 }

--- a/tool/src/main/java/org/icann/rdapconformance/tool/RdapConformanceTool.java
+++ b/tool/src/main/java/org/icann/rdapconformance/tool/RdapConformanceTool.java
@@ -15,6 +15,7 @@ import java.util.concurrent.Callable;
 import org.apache.commons.lang3.SystemUtils;
 import org.everit.json.schema.internal.IPV4Validator;
 import org.everit.json.schema.internal.IPV6Validator;
+import org.icann.rdapconformance.validator.*;
 import org.icann.rdapconformance.validator.workflow.rdap.*;
 import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidator;
 import org.slf4j.LoggerFactory;
@@ -26,11 +27,6 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
-import org.icann.rdapconformance.validator.CommonUtils;
-import org.icann.rdapconformance.validator.DNSCacheResolver;
-import org.icann.rdapconformance.validator.ProgressCallback;
-import org.icann.rdapconformance.validator.QueryContext;
-import org.icann.rdapconformance.validator.ToolResult;
 import org.icann.rdapconformance.validator.configuration.ConfigurationFile;
 import org.icann.rdapconformance.validator.configuration.RDAPValidatorConfiguration;
 import org.icann.rdapconformance.validator.workflow.FileSystem;
@@ -1398,22 +1394,7 @@ public void setShowProgress(boolean showProgress) {
     }
 
     private static boolean hasMixedLabelsInDomain(String domainName) {
-      boolean hasALabel = false;
-      boolean hasULabel = false;
-      for (String label : domainName.split("\\.")) {
-        if (label.toLowerCase().startsWith("xn--")) {
-          hasALabel = true;
-        } else {
-          for (char c : label.toCharArray()) {
-            if (c > 127) {
-              hasULabel = true;
-              break;
-            }
-          }
-        }
-        if (hasALabel && hasULabel) return true;
-      }
-      return false;
+      return DomainLabelUtils.hasMixedLabels(domainName);
     }
   }
 }

--- a/validator/src/main/java/org/icann/rdapconformance/validator/DomainLabelUtils.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/DomainLabelUtils.java
@@ -1,0 +1,77 @@
+package org.icann.rdapconformance.validator;
+
+import java.net.URLDecoder;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Shared utilities for domain label type detection (A-label vs U-label).
+ * Used by both IdnAwareUriConverter and RDAPHttpQueryTypeProcessor to ensure
+ * consistent mixed-label detection across URI normalization and validation.
+ */
+public final class DomainLabelUtils {
+
+    private DomainLabelUtils() {}
+
+    /**
+     * Returns true if the domain name contains both A-labels (xn--) and U-labels (non-ASCII
+     * or percent-encoded non-ASCII bytes), which is invalid per RFC 5891.
+     * Handles both decoded Unicode and percent-encoded forms (e.g. %E4%BE%8B).
+     */
+    public static boolean hasMixedLabels(String domainName) {
+        if (domainName == null || domainName.isEmpty()) {
+            return false;
+        }
+
+        // Try to decode percent-encoded chars first
+        String decoded = domainName;
+        try {
+            decoded = URLDecoder.decode(domainName, "UTF-8");
+        } catch (Exception e) {
+            // decode failed — fall through to percent-encoded check below
+        }
+
+        boolean hasALabel = false;
+        boolean hasULabel = false;
+
+        for (String label : decoded.split("\\.")) {
+            if (label.toLowerCase().startsWith("xn--")) {
+                hasALabel = true;
+            } else if (!isAscii(label)) {
+                hasULabel = true;
+            }
+            if (hasALabel && hasULabel) return true;
+        }
+
+        // If decode failed (decoded == domainName), also check raw percent sequences
+        if (decoded.equals(domainName)) {
+            for (String label : domainName.split("\\.")) {
+                if (label.toLowerCase().startsWith("xn--")) {
+                    hasALabel = true;
+                } else if (label.contains("%")) {
+                    Matcher m =
+                            Pattern.compile("%([0-9A-Fa-f]{2})").matcher(label);
+                    while (m.find()) {
+                        if (Integer.parseInt(m.group(1), 16) > 0x7F) {
+                            hasULabel = true;
+                            break;
+                        }
+                    }
+                }
+                if (hasALabel && hasULabel) return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns true if the string contains only ASCII characters (codepoints 0–127).
+     */
+    public static boolean isAscii(String s) {
+        for (int i = 0; i < s.length(); i++) {
+            if (s.charAt(i) > 127) return false;
+        }
+        return true;
+    }
+}

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQueryTypeProcessor.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQueryTypeProcessor.java
@@ -2,6 +2,7 @@ package org.icann.rdapconformance.validator.workflow.rdap.http;
 
 import static org.icann.rdapconformance.validator.CommonUtils.EMPTY_STRING;
 
+import org.icann.rdapconformance.validator.DomainLabelUtils;
 import org.icann.rdapconformance.validator.QueryContext;
 
 import java.util.Set;
@@ -17,6 +18,8 @@ import org.icann.rdapconformance.validator.SchemaValidator;
 import org.icann.rdapconformance.validator.workflow.SchemaValidatorCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 
 public class RDAPHttpQueryTypeProcessor implements RDAPQueryTypeProcessor {
 
@@ -70,12 +73,10 @@ public class RDAPHttpQueryTypeProcessor implements RDAPQueryTypeProcessor {
             String rawDomainName = queryType.getValue(this.config.getUri().getRawPath());
             String domainName;
             try {
-                domainName = java.net.URLDecoder.decode(rawDomainName, java.nio.charset.StandardCharsets.UTF_8);
+                domainName = URLDecoder.decode(rawDomainName, StandardCharsets.UTF_8);
             } catch (Exception e) {
                 domainName = rawDomainName;
             }
-            logger.error("DEBUG domainName for mixed label check: [{}]", domainName); // ← temporal
-            logger.error("DEBUG hasMixedLabels result: [{}]", hasMixedLabels(domainName)); // ← temporal
 
             if (hasMixedLabels(domainName)) {
                 logger.error("Mixed label format detected in domain name: {}", domainName);
@@ -135,56 +136,7 @@ public class RDAPHttpQueryTypeProcessor implements RDAPQueryTypeProcessor {
      * @return true if the domain name contains mixed labels, false otherwise
      */
     public boolean hasMixedLabels(String domainName) {
-        if (domainName == null || domainName.isEmpty()) {
-            return false;
-        }
-
-        // Try to decode percent-encoded chars first
-        String decoded = domainName;
-        try {
-            decoded = java.net.URLDecoder.decode(domainName, "UTF-8");
-        } catch (Exception e) {
-            // if decode fails, work with original but also check percent-encoded patterns
-        }
-
-        String[] labels = decoded.split("\\.");
-        boolean hasALabel = false;
-        boolean hasULabel = false;
-
-        for (String label : labels) {
-            if (label.toLowerCase().startsWith("xn--")) {
-                hasALabel = true;
-            } else if (!isAscii(label)) {
-                hasULabel = true;
-            }
-            if (hasALabel && hasULabel) return true;
-        }
-
-        // Also check original (undecoded) for percent-encoded non-ASCII
-        // e.g. %E4%BE%8B%E5%AD%90 where first byte > 0x7F
-        if (!decoded.equals(domainName)) {
-            return false; // already decoded successfully above
-        }
-
-        // decoded == domainName means decode failed — check raw percent sequences
-        for (String label : domainName.split("\\.")) {
-            if (label.toLowerCase().startsWith("xn--")) {
-                hasALabel = true;
-            } else if (label.contains("%")) {
-                // Check if any percent-encoded byte is > 0x7F (non-ASCII)
-                java.util.regex.Matcher m = java.util.regex.Pattern.compile("%([0-9A-Fa-f]{2})").matcher(label);
-                while (m.find()) {
-                    int byteVal = Integer.parseInt(m.group(1), 16);
-                    if (byteVal > 0x7F) {
-                        hasULabel = true;
-                        break;
-                    }
-                }
-            }
-            if (hasALabel && hasULabel) return true;
-        }
-
-        return false;
+        return DomainLabelUtils.hasMixedLabels(domainName);
     }
 
     /**
@@ -194,12 +146,7 @@ public class RDAPHttpQueryTypeProcessor implements RDAPQueryTypeProcessor {
      * @return true if the string contains only ASCII characters, false otherwise
      */
     public boolean isAscii(String s) {
-        for (int i = 0; i < s.length(); i++) {
-            if (s.charAt(i) > 127) {
-                return false;
-            }
-        }
-        return true;
+        return DomainLabelUtils.isAscii(s);
     }
 
     public enum RDAPHttpQueryType {

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQueryTypeProcessor.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQueryTypeProcessor.java
@@ -67,9 +67,16 @@ public class RDAPHttpQueryTypeProcessor implements RDAPQueryTypeProcessor {
         }
 
         if (Set.of(RDAPHttpQueryType.DOMAIN, RDAPHttpQueryType.NAMESERVER).contains(queryType)) {
-            String domainName = queryType.getValue(this.config.getUri().toString());
+            String rawDomainName = queryType.getValue(this.config.getUri().getRawPath());
+            String domainName;
+            try {
+                domainName = java.net.URLDecoder.decode(rawDomainName, java.nio.charset.StandardCharsets.UTF_8);
+            } catch (Exception e) {
+                domainName = rawDomainName;
+            }
+            logger.error("DEBUG domainName for mixed label check: [{}]", domainName); // ← temporal
+            logger.error("DEBUG hasMixedLabels result: [{}]", hasMixedLabels(domainName)); // ← temporal
 
-            // Check for mixed labels first
             if (hasMixedLabels(domainName)) {
                 logger.error("Mixed label format detected in domain name: {}", domainName);
                 status = ToolResult.MIXED_LABEL_FORMAT;
@@ -132,7 +139,15 @@ public class RDAPHttpQueryTypeProcessor implements RDAPQueryTypeProcessor {
             return false;
         }
 
-        String[] labels = domainName.split("\\.");
+        // Try to decode percent-encoded chars first
+        String decoded = domainName;
+        try {
+            decoded = java.net.URLDecoder.decode(domainName, "UTF-8");
+        } catch (Exception e) {
+            // if decode fails, work with original but also check percent-encoded patterns
+        }
+
+        String[] labels = decoded.split("\\.");
         boolean hasALabel = false;
         boolean hasULabel = false;
 
@@ -142,12 +157,31 @@ public class RDAPHttpQueryTypeProcessor implements RDAPQueryTypeProcessor {
             } else if (!isAscii(label)) {
                 hasULabel = true;
             }
+            if (hasALabel && hasULabel) return true;
+        }
 
-            // If we found both types, we have mixed labels
-            if (hasALabel && hasULabel) {
-                logger.debug("Domain name contains mixed A-labels and U-labels: {}", domainName);
-                return true;
+        // Also check original (undecoded) for percent-encoded non-ASCII
+        // e.g. %E4%BE%8B%E5%AD%90 where first byte > 0x7F
+        if (!decoded.equals(domainName)) {
+            return false; // already decoded successfully above
+        }
+
+        // decoded == domainName means decode failed — check raw percent sequences
+        for (String label : domainName.split("\\.")) {
+            if (label.toLowerCase().startsWith("xn--")) {
+                hasALabel = true;
+            } else if (label.contains("%")) {
+                // Check if any percent-encoded byte is > 0x7F (non-ASCII)
+                java.util.regex.Matcher m = java.util.regex.Pattern.compile("%([0-9A-Fa-f]{2})").matcher(label);
+                while (m.find()) {
+                    int byteVal = Integer.parseInt(m.group(1), 16);
+                    if (byteVal > 0x7F) {
+                        hasULabel = true;
+                        break;
+                    }
+                }
             }
+            if (hasALabel && hasULabel) return true;
         }
 
         return false;


### PR DESCRIPTION
## Required Information

### PR Description (Include comprehensive description)

#### Summary of changes:
Changes:
- IdnAwareUriConverter.convertIdnInPath(): detect mixed labels before
  converting — if mixed, percent-encode U-labels without punycode conversion
  so the raw Unicode is preserved for downstream detection
- RDAPHttpQueryTypeProcessor.hasMixedLabels(): extend to detect
  percent-encoded non-ASCII bytes (e.g. %E4 > 0x7F) as U-labels, handling
  the case where URLDecoder fails or the label is still percent-encoded
- RDAPHttpQueryTypeProcessor.check(): decode rawPath via URLDecoder before
  calling hasMixedLabels() so both encoded and unencoded forms are detected

Pure U-label domains (e.g. nic.дети) are unaffected — they continue to be
normalized to punycode correctly as per the IDN story.
#### Problem/feature addressed:
Prior to this fix, querying a domain URL with mixed A-labels and U-labels
(e.g. boo.xn--mller-kva.例子) was not returning exit code 4 (MIXED_LABEL_FORMAT)
because IdnAwareUriConverter was converting U-labels (例子) to punycode
(xn--fsqu00a) before the mixed-label check ran in RDAPHttpQueryTypeProcessor,
making the domain appear as all-A-labels and bypassing the check entirely.

Root cause: convertIdnInPath() in IdnAwareUriConverter converted ALL U-labels
to punycode unconditionally, including in mixed-label domains where the
conversion should be rejected instead.
#### Relevant screenshots/diagrams:

#### Links to relevant issues/tasks:
https://icann-jira.atlassian.net/browse/RCT-477
### Branch Name

- [x] Does the branch name follow the Branch Naming Convention?

#### If not, explain why:

### Code Changes

- [x] Are code changes adhering to coding standards and practices?

#### If not, explain why:

### Commit Messages

- [ ] Do commit messages follow [Conventional Commits guidelines](https://wecann.icann.org/docs/DOC-40501)?
- [x] Are they clear, concise, and informative using imperative language?

#### If not, explain why:

### Tests and Test Coverage

- [x] Are changes covered by appropriate tests?
- [ ] Were unit tests, integration tests, and end-to-end tests run?
- [ ] Was the test coverage maintained or improved? Please include before/after results.

#### If not, explain why:

### Bug Fixes and Tests

- [ ] For bug fixes, are there:
    - [x] Tests that reproduce the bug before the changes?
    - [ ] Tests that demonstrate the bug is resolved after the changes?

#### If not, explain why:

### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Documentation

- [ ] Are there updates to documentation that need to be made?
- [x] Are they included or linked in the PR description?

#### If not, explain why:

### PR Size

- [x] Is the PR small and focused on one logical change?

#### If not, explain why:

---