### PR TITLE
bug: validate-code-10300-response

### DIFF
--- a/tool/src/main/java/org/icann/rdapconformance/tool/RdapConformanceTool.java
+++ b/tool/src/main/java/org/icann/rdapconformance/tool/RdapConformanceTool.java
@@ -1318,7 +1318,15 @@ public void setShowProgress(boolean showProgress) {
             // Not a port
           }
         }
-        normalizedHostPort = toASCII(hostOnly) + portSuffix;
+        String convertedHost;
+        try {
+          convertedHost = toASCII(hostOnly);
+        } catch (IllegalArgumentException e) {
+          // Host label too long or invalid — leave as-is
+          logger.debug("IDN toASCII skipped for host '{}': {}", hostOnly, e.getMessage());
+          convertedHost = hostOnly;
+        }
+        normalizedHostPort = convertedHost + portSuffix;
       }
 
       // Now percent-encode non-ASCII in the remaining part (path/query/fragment)
@@ -1385,7 +1393,13 @@ public void setShowProgress(boolean showProgress) {
             return before + encoded;
           }
 
-          domainName = toASCII(domainName);
+          try {
+            domainName = toASCII(domainName);
+          } catch (IllegalArgumentException e) {
+            // Label too long or otherwise invalid for IDN conversion — leave as-is
+            // so downstream schema validation can detect and report it (e.g. -10300)
+            logger.debug("IDN toASCII skipped for '{}': {}", domainName, e.getMessage());
+          }
           return before + domainName;
         }
       }

--- a/tool/src/test/java/org/icann/rdapconformance/tool/IdnAwareUriConverterTest.java
+++ b/tool/src/test/java/org/icann/rdapconformance/tool/IdnAwareUriConverterTest.java
@@ -32,6 +32,8 @@ public class IdnAwareUriConverterTest {
                 { "/rdap/help", "/rdap/help" },
                 // Unicode TLD only
                 { "/rdap/domain/test.münchen", "/rdap/domain/test.xn--mnchen-3ya" },
+                { "/rdap/domain/reallylongdnslabelthatislongerthan63characterswegowithinvalid064.registryok",
+                "/rdap/domain/reallylongdnslabelthatislongerthan63characterswegowithinvalid064.registryok" },
         };
     }
 
@@ -65,6 +67,11 @@ public class IdnAwareUriConverterTest {
                 {
                         "https://whois.nic.дети/rdap/domain/nic.дети",
                         "https://whois.nic.xn--d1acj3b/rdap/domain/nic.xn--d1acj3b"
+                },
+                // Label > 63 chars in full URI — must not throw, passes through as-is
+                {
+                        "https://ts-wire-mock.icann.org/rdap/v2/code_10202/domain/reallylongdnslabelthatislongerthan63characterswegowithinvalid064.registryok",
+                        "https://ts-wire-mock.icann.org/rdap/v2/code_10202/domain/reallylongdnslabelthatislongerthan63characterswegowithinvalid064.registryok"
                 },
         };
     }
@@ -113,5 +120,15 @@ public class IdnAwareUriConverterTest {
         URI result = converter.convert("https://example.com/rdap/domain/nic.дети?foo=bar");
         assertThat(result.getPath()).isEqualTo("/rdap/domain/nic.xn--d1acj3b");
         assertThat(result.getQuery()).isEqualTo("foo=bar");
+    }
+
+    /** * A domain label longer than 63 characters must pass through as-is * so that downstream validation can report -10300. * Before the fix, toASCII() threw IllegalArgumentException causing exit 25. */
+    @Test
+    public void testConvertIdnInPath_LabelTooLong_PassesThrough() {
+        String longLabel = "reallylongdnslabelthatislongerthan63characterswegowithinvalid064";
+        String path = "/rdap/domain/" + longLabel + ".registryok";
+        String result = RdapConformanceTool.IdnAwareUriConverter.convertIdnInPath(path);
+        // Must not throw, must return the domain unchanged
+        assertThat(result).contains(longLabel + ".registryok");
     }
 }

--- a/tool/src/test/java/org/icann/rdapconformance/tool/IdnAwareUriConverterTest.java
+++ b/tool/src/test/java/org/icann/rdapconformance/tool/IdnAwareUriConverterTest.java
@@ -122,13 +122,17 @@ public class IdnAwareUriConverterTest {
         assertThat(result.getQuery()).isEqualTo("foo=bar");
     }
 
-    /** * A domain label longer than 63 characters must pass through as-is * so that downstream validation can report -10300. * Before the fix, toASCII() threw IllegalArgumentException causing exit 25. */
+    /**
+     * A domain label longer than 63 characters must pass through as-is
+     * so that downstream validation can report -10300.
+     * Before the fix, toASCII() threw IllegalArgumentException causing exit 25.
+     **/
     @Test
     public void testConvertIdnInPath_LabelTooLong_PassesThrough() {
         String longLabel = "reallylongdnslabelthatislongerthan63characterswegowithinvalid064";
         String path = "/rdap/domain/" + longLabel + ".registryok";
         String result = RdapConformanceTool.IdnAwareUriConverter.convertIdnInPath(path);
-        // Must not throw, must return the domain unchanged
-        assertThat(result).contains(longLabel + ".registryok");
+        // Must not throw, must return the path unchanged
+        assertThat(result).isEqualTo(path);
     }
 }

--- a/tool/src/test/java/org/icann/rdapconformance/tool/RdapWebValidatorTest.java
+++ b/tool/src/test/java/org/icann/rdapconformance/tool/RdapWebValidatorTest.java
@@ -572,6 +572,23 @@ public class RdapWebValidatorTest {
     }
 
     /**
+     * A URI with a DNS label longer than 63 characters must not throw
+     * IllegalArgumentException from IDN toASCII — it should be accepted as-is
+     * so downstream validation can report -10300.
+     */
+    @Test
+    public void testValidateAndCreateURI_LabelTooLong_DoesNotThrow() {
+        String uri = "https://ts-wire-mock.icann.org/rdap/v2/code_10202/domain/" +
+                "reallylongdnslabelthatislongerthan63characterswegowithinvalid064.registryok";
+
+        URI result = RdapWebValidator.validateAndCreateURI(uri);
+
+        assertNotNull(result);
+        assertThat(result.toString()).contains(
+                "reallylongdnslabelthatislongerthan63characterswegowithinvalid064.registryok");
+    }
+
+    /**
      * Helper method to recursively delete directories for test cleanup.
      */
     private void deleteDirectoryRecursively(Path directory) throws IOException {

--- a/tool/src/test/java/org/icann/rdapconformance/tool/RdapWebValidatorTest.java
+++ b/tool/src/test/java/org/icann/rdapconformance/tool/RdapWebValidatorTest.java
@@ -584,8 +584,7 @@ public class RdapWebValidatorTest {
         URI result = RdapWebValidator.validateAndCreateURI(uri);
 
         assertNotNull(result);
-        assertThat(result.toString()).contains(
-                "reallylongdnslabelthatislongerthan63characterswegowithinvalid064.registryok");
+        assertThat(result.toString()).isEqualTo(uri);
     }
 
     /**


### PR DESCRIPTION
## Required Information

### PR Description (Include comprehensive description)

#### Summary of changes:
After those changes, convertIdnInPath() calls java.net.IDN.toASCII()
on ALL domain/nameserver path segments — including ASCII-only ones —
and toASCII() throws IllegalArgumentException for labels > 63 chars,
causing the tool to exit BAD_USER_INPUT (25) instead of SUCCESS (0)
with -10300 in the result file.

Fix: wrap toASCII() calls in convertIdnInPath() and normalizeIdnUri()
with try/catch(IllegalArgumentException) to pass the domain through
as-is when IDN conversion fails, restoring the original behavior for
oversized-label domains and allowing -10300 to be reported correctly.
#### Problem/feature addressed:
fix: handle IDN toASCII failure for oversized DNS labels gracefully

Before the IdnAwareUriConverter changes, ASCII-only URIs were passed
directly to java.net.URI which accepts labels longer than 63 chars
without complaint, allowing -10300 validation to run normally.
#### Relevant screenshots/diagrams:

#### Links to relevant issues/tasks:
https://icann-jira.atlassian.net/browse/RCT-477
### Branch Name

- [x] Does the branch name follow the Branch Naming Convention?

#### If not, explain why:

### Code Changes

- [x] Are code changes adhering to coding standards and practices?

#### If not, explain why:

### Commit Messages

- [ ] Do commit messages follow [Conventional Commits guidelines](https://wecann.icann.org/docs/DOC-40501)?
- [x] Are they clear, concise, and informative using imperative language?

#### If not, explain why:

### Tests and Test Coverage

- [x] Are changes covered by appropriate tests?
- [ ] Were unit tests, integration tests, and end-to-end tests run?
- [ ] Was the test coverage maintained or improved? Please include before/after results.

#### If not, explain why:

### Bug Fixes and Tests

- [ ] For bug fixes, are there:
    - [x] Tests that reproduce the bug before the changes?
    - [ ] Tests that demonstrate the bug is resolved after the changes?

#### If not, explain why:

### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Documentation

- [ ] Are there updates to documentation that need to be made?
- [x] Are they included or linked in the PR description?

#### If not, explain why:

### PR Size

- [x] Is the PR small and focused on one logical change?

#### If not, explain why:

---