### PR TITLE
bug/RCT-475-ErrorCode 12100 is not getting triggered for the condition met

### DIFF
--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
@@ -215,8 +215,10 @@ public class RDAPHttpQuery implements RDAPQuery {
             String rdapResponse = httpResponse.body();
 
             if (httpStatusCode != HTTP_OK) {
-                // Skip if body is not a valid JSON object — -13001 and -12100 already cover this
-                if (rdapResponse == null || !rdapResponse.trim().startsWith("{")) {
+                // Skip if body is not a JSON object (e.g. array or unparseable).
+                // jsonResponse is populated by validate(); if it's null or an array,
+                // -13001 or -12100 already cover the structural issue.
+                if (jsonResponse == null || !jsonResponse.isValid() || jsonResponse.isArray()) {
                     return;
                 }
                 if (!validateIfContainsErrorCode(httpStatusCode, rdapResponse)) {

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
@@ -210,12 +210,15 @@ public class RDAPHttpQuery implements RDAPQuery {
 
     @Override
     public void addErrorsTo404RdapResponse() {
-        // Check for errorCode presence and correctness in non-200 responses
         if (isQuerySuccessful() && httpResponse != null) {
             int httpStatusCode = httpResponse.statusCode();
             String rdapResponse = httpResponse.body();
 
             if (httpStatusCode != HTTP_OK) {
+                // Skip if body is not a valid JSON object — -13001 and -12100 already cover this
+                if (rdapResponse == null || !rdapResponse.trim().startsWith("{")) {
+                    return;
+                }
                 if (!validateIfContainsErrorCode(httpStatusCode, rdapResponse)) {
                     queryContext.addError(-12107, rdapResponse, "The rdapConformance must be present and must be an array of strings.");
                 } else if (!validateErrorCodeMatchesHttpStatus(httpStatusCode, rdapResponse)) {

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
@@ -215,9 +215,9 @@ public class RDAPHttpQuery implements RDAPQuery {
             String rdapResponse = httpResponse.body();
 
             if (httpStatusCode != HTTP_OK) {
-                // Skip if body is not a JSON object (e.g. array or unparseable).
-                // jsonResponse is populated by validate(); if it's null or an array,
-                // -13001 or -12100 already cover the structural issue.
+                // Skip if the body was not parsed as a JSON object (null, unparseable, or a JSON array).
+                // Non-object bodies are already covered by -13001 (invalid JSON) or -12100 (schema invalid);
+                // running -12107/-12108 on them would produce false positives.
                 if (jsonResponse == null || !jsonResponse.isValid() || jsonResponse.isArray()) {
                     return;
                 }

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
@@ -530,7 +530,11 @@ public class RDAPHttpQuery implements RDAPQuery {
         jsonResponse = new JsonData(rdapResponse);
         if (!jsonResponse.isValid()) {
             queryContext.addError(-13001, "response body not given", "The response was not valid JSON.");
-            isQuerySuccessful = false;
+            // For 404 responses, allow validation to continue so rdap_error.json
+            // schema validator can emit -12100. For all other status codes, stop.
+            if (httpStatusCode != HTTP_NOT_FOUND) {
+                isQuerySuccessful = false;
+            }
         }
     }
 

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQueryStatusCodeTest.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQueryStatusCodeTest.java
@@ -19,7 +19,7 @@ import java.util.Set;
 import org.icann.rdapconformance.validator.QueryContext;
 import org.icann.rdapconformance.validator.configuration.RDAPValidatorConfiguration;
 import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidationResult;
-import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidatorResultsImpl;
+import org.icann.rdapconformance.validator.workflow.rdap.RDAPValidator;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
@@ -969,8 +969,8 @@ public class RDAPHttpQueryStatusCodeTest {
         QueryContext integrationContext = QueryContext.create(config, queryContext.getDatasetService(), rdapHttpQuery);
         integrationContext.setSsrfProtectionEnabled(false);
 
-        org.icann.rdapconformance.validator.workflow.rdap.RDAPValidator validator =
-                new org.icann.rdapconformance.validator.workflow.rdap.RDAPValidator(integrationContext);
+        RDAPValidator validator =
+                new RDAPValidator(integrationContext);
 
         validator.validate();
 
@@ -1008,8 +1008,8 @@ public class RDAPHttpQueryStatusCodeTest {
         QueryContext integrationContext = QueryContext.create(config, queryContext.getDatasetService(), rdapHttpQuery);
         integrationContext.setSsrfProtectionEnabled(false);
 
-        org.icann.rdapconformance.validator.workflow.rdap.RDAPValidator validator =
-                new org.icann.rdapconformance.validator.workflow.rdap.RDAPValidator(integrationContext);
+        RDAPValidator validator =
+                new RDAPValidator(integrationContext);
 
         validator.validate();
 

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQueryStatusCodeTest.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQueryStatusCodeTest.java
@@ -559,32 +559,36 @@ public class RDAPHttpQueryStatusCodeTest {
         assertFalse(has12107, "Invalid errorCode format should not trigger -12107 (errorCode exists)");
     }
 
-    @Test  
+    @Test
     public void testMalformedJsonResponse() {
-        System.out.println("\n=== Test: Malformed JSON Response ===");
-        
+        System.out.println("\n=== Test: Malformed JSON Response (404 + incomplete JSON) ===");
+
         doReturn(true).when(config).useRdapProfileFeb2024();
-        
+
         String testPath = "/rdap/domain/malformed.com";
         String baseUrl = "http://localhost:" + wireMockServer.port();
         URI testUri = URI.create(baseUrl + testPath);
         doReturn(testUri).when(config).getUri();
-        
-        // Malformed JSON response
-        String responseBody = "{\"rdapConformance\": [\"rdap_level_0\"], \"errorCode\":"; // incomplete JSON
-        
+
+        // Malformed JSON — starts with '{' but is incomplete
+        String responseBody = "{\"rdapConformance\": [\"rdap_level_0\"], \"errorCode\":";
+
         stubFor(get(urlEqualTo(testPath))
-            .willReturn(aResponse()
-                .withStatus(404)
-                .withHeader("Content-Type", "application/rdap+json")
-                .withBody(responseBody)));
+                .willReturn(aResponse()
+                        .withStatus(404)
+                        .withHeader("Content-Type", "application/rdap+json")
+                        .withBody(responseBody)));
 
         RDAPHttpQuery query = new RDAPHttpQuery(config);
         query.setQueryContext(queryContext);
-        query.run();
 
-        // Simulate RDAPValidator flow — with the fix, run() stays successful for 404
-        // even with malformed JSON, so addErrorsTo404RdapResponse() IS reached.
+        // run() must return true for 404 even with invalid JSON so RDAPValidator
+        // can continue and schema validation can emit -12100
+        boolean runResult = query.run();
+        assertTrue(runResult, "run() should return true for 404 even with malformed JSON");
+        assertTrue(query.isErrorContent(), "404 should be treated as error content");
+
+        // Simulate RDAPValidator flow
         if (query.isErrorContent()) {
             query.addErrorsTo404RdapResponse();
         }
@@ -595,15 +599,52 @@ public class RDAPHttpQueryStatusCodeTest {
         boolean has12107 = allResults.stream().anyMatch(r -> r.getCode() == -12107);
         boolean has13001 = allResults.stream().anyMatch(r -> r.getCode() == -13001);
 
-        // With the fix, malformed JSON on a 404 response:
-        // - triggers -13001 (invalid JSON at HTTP level)
-        // - triggers -12107 (rdapConformance missing, because JSON can't be parsed)
-        // - does NOT trigger -12108
+        // -13001: invalid JSON at HTTP level
+        // -12107: rdapConformance missing (JSON parse fails in validateIfContainsErrorCode)
+        // -12108: should NOT appear
         assertTrue(has13001, "Malformed JSON should trigger -13001");
-        assertTrue(has12107, "Malformed 404 JSON triggers -12107 since rdapConformance cannot be found");
+        assertTrue(has12107, "Malformed 404 JSON triggers -12107 since rdapConformance cannot be parsed");
         assertFalse(has12108, "Malformed JSON should not trigger -12108");
-        
-        System.out.println("SUCCESS: Malformed JSON correctly handled");
+    }
+
+    @Test
+    public void testArrayBodyOnErrorResponse_DoesNotTriggerFalsePositive12107() {
+        System.out.println("\n=== Test: Array body on 404 — no false -12107 ===");
+
+        doReturn(true).when(config).useRdapProfileFeb2024();
+
+        String testPath = "/rdap/domain/array-body.com";
+        String baseUrl = "http://localhost:" + wireMockServer.port();
+        URI testUri = URI.create(baseUrl + testPath);
+        doReturn(testUri).when(config).getUri();
+
+        stubFor(get(urlEqualTo(testPath))
+                .willReturn(aResponse()
+                        .withStatus(404)
+                        .withHeader("Content-Type", "application/rdap+json")
+                        .withBody("[]")));
+
+        RDAPHttpQuery query = new RDAPHttpQuery(config);
+        query.setQueryContext(queryContext);
+
+        // [] is valid JSON (a list), so run() stays true for 404
+        boolean runResult = query.run();
+        assertTrue(runResult, "run() should return true for 404 with array body");
+        assertTrue(query.isErrorContent(), "404 should be treated as error content");
+
+        if (query.isErrorContent()) {
+            query.addErrorsTo404RdapResponse();
+        }
+
+        Set<RDAPValidationResult> allResults = queryContext.getResults().getAll();
+
+        boolean has12107 = allResults.stream().anyMatch(r -> r.getCode() == -12107);
+        boolean has13001 = allResults.stream().anyMatch(r -> r.getCode() == -13001);
+
+        // [] is valid JSON so -13001 is NOT emitted
+        // [] does not start with '{' so addErrorsTo404RdapResponse() guard skips -12107
+        assertFalse(has13001, "[] is valid JSON — -13001 should NOT be emitted");
+        assertFalse(has12107, "Array body should NOT trigger -12107 — guard prevents false positive");
     }
 
     @Test

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQueryStatusCodeTest.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQueryStatusCodeTest.java
@@ -583,9 +583,8 @@ public class RDAPHttpQueryStatusCodeTest {
         query.setQueryContext(queryContext);
         query.run();
 
-        // Simulate RDAPValidator flow — but note: run() returns false for malformed JSON,
-        // so RDAPValidator would return early. addErrorsTo404RdapResponse is never reached.
-        // Even if we call it, isQuerySuccessful() is false so it's a no-op.
+        // Simulate RDAPValidator flow — with the fix, run() stays successful for 404
+        // even with malformed JSON, so addErrorsTo404RdapResponse() IS reached.
         if (query.isErrorContent()) {
             query.addErrorsTo404RdapResponse();
         }
@@ -596,11 +595,13 @@ public class RDAPHttpQueryStatusCodeTest {
         boolean has12107 = allResults.stream().anyMatch(r -> r.getCode() == -12107);
         boolean has13001 = allResults.stream().anyMatch(r -> r.getCode() == -13001);
 
-        // Malformed JSON is caught by -13001 in validate(). Since isQuerySuccessful=false,
-        // addErrorsTo404RdapResponse() is a no-op, so no -12107.
-        assertFalse(has12107, "Malformed JSON is captured by -13001, not -12107");
-        assertFalse(has12108, "Malformed JSON should not trigger -12108");
+        // With the fix, malformed JSON on a 404 response:
+        // - triggers -13001 (invalid JSON at HTTP level)
+        // - triggers -12107 (rdapConformance missing, because JSON can't be parsed)
+        // - does NOT trigger -12108
         assertTrue(has13001, "Malformed JSON should trigger -13001");
+        assertTrue(has12107, "Malformed 404 JSON triggers -12107 since rdapConformance cannot be found");
+        assertFalse(has12108, "Malformed JSON should not trigger -12108");
         
         System.out.println("SUCCESS: Malformed JSON correctly handled");
     }

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQueryStatusCodeTest.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQueryStatusCodeTest.java
@@ -599,11 +599,9 @@ public class RDAPHttpQueryStatusCodeTest {
         boolean has12107 = allResults.stream().anyMatch(r -> r.getCode() == -12107);
         boolean has13001 = allResults.stream().anyMatch(r -> r.getCode() == -13001);
 
-        // -13001: invalid JSON at HTTP level
-        // -12107: rdapConformance missing (JSON parse fails in validateIfContainsErrorCode)
-        // -12108: should NOT appear
+        // JSON malformed (isValid=false) → addErrorsTo404RdapResponse() is no-op only -13001 is emitted
         assertTrue(has13001, "Malformed JSON should trigger -13001");
-        assertTrue(has12107, "Malformed 404 JSON triggers -12107 since rdapConformance cannot be parsed");
+        assertFalse(has12107, "Malformed JSON: body is not parseable, -12107 should NOT be emitted");
         assertFalse(has12108, "Malformed JSON should not trigger -12108");
     }
 
@@ -936,6 +934,89 @@ public class RDAPHttpQueryStatusCodeTest {
 
 
         System.out.println("SUCCESS: String parsing exception correctly handled");
+    }
+
+    /**
+     * Integration test: RDAPValidator + RDAPHttpQuery end-to-end for 404 + invalid JSON body.
+     * Verifies RCT-475 regression: -12100 must be emitted when error response body is malformed JSON.
+     */
+    @Test
+    public void testIntegration_404WithMalformedJson_Emits12100() {
+        doReturn(true).when(config).check();
+        doReturn(false).when(config).isAdditionalConformanceQueries();
+        doReturn(false).when(config).isNetworkEnabled();
+        doReturn(false).when(config).isThin();
+        doReturn(false).when(config).isGtldRegistry();
+        doReturn(false).when(config).useRdapProfileFeb2024();
+        doReturn(false).when(config).isGtldRegistrar();
+
+        String testPath = "/rdap/domain/malformed-integration.com";
+        String baseUrl = "http://localhost:" + wireMockServer.port();
+        URI testUri = URI.create(baseUrl + testPath);
+        doReturn(testUri).when(config).getUri();
+
+        stubFor(get(urlEqualTo(testPath))
+                .willReturn(aResponse()
+                        .withStatus(404)
+                        .withHeader("Content-Type", "application/rdap+json")
+                        .withBody("{\"rdapConformance\": [\"rdap_level_0\"], \"errorCode\":")));
+
+        RDAPHttpQuery rdapHttpQuery = new RDAPHttpQuery(config);
+        rdapHttpQuery.ssrfProtectionEnabled = false;
+        rdapHttpQuery.setQueryContext(queryContext);
+
+        // Reuse the same queryContext — replace its query with rdapHttpQuery
+        QueryContext integrationContext = QueryContext.create(config, queryContext.getDatasetService(), rdapHttpQuery);
+        integrationContext.setSsrfProtectionEnabled(false);
+
+        org.icann.rdapconformance.validator.workflow.rdap.RDAPValidator validator =
+                new org.icann.rdapconformance.validator.workflow.rdap.RDAPValidator(integrationContext);
+
+        validator.validate();
+
+        Set<RDAPValidationResult> allResults = integrationContext.getResults().getAll();
+        boolean has12100 = allResults.stream().anyMatch(r -> r.getCode() == -12100);
+
+        assertTrue(has12100, "RDAPValidator must emit -12100 for 404 + malformed JSON (RCT-475)");
+    }
+
+    @Test
+    public void testIntegration_404WithArrayBody_Emits12100() {
+        doReturn(true).when(config).check();
+        doReturn(false).when(config).isAdditionalConformanceQueries();
+        doReturn(false).when(config).isNetworkEnabled();
+        doReturn(false).when(config).isThin();
+        doReturn(false).when(config).isGtldRegistry();
+        doReturn(false).when(config).useRdapProfileFeb2024();
+        doReturn(false).when(config).isGtldRegistrar();
+
+        String testPath = "/rdap/domain/array-integration.com";
+        String baseUrl = "http://localhost:" + wireMockServer.port();
+        URI testUri = URI.create(baseUrl + testPath);
+        doReturn(testUri).when(config).getUri();
+
+        stubFor(get(urlEqualTo(testPath))
+                .willReturn(aResponse()
+                        .withStatus(404)
+                        .withHeader("Content-Type", "application/rdap+json")
+                        .withBody("[]")));
+
+        RDAPHttpQuery rdapHttpQuery = new RDAPHttpQuery(config);
+        rdapHttpQuery.ssrfProtectionEnabled = false;
+        rdapHttpQuery.setQueryContext(queryContext);
+
+        QueryContext integrationContext = QueryContext.create(config, queryContext.getDatasetService(), rdapHttpQuery);
+        integrationContext.setSsrfProtectionEnabled(false);
+
+        org.icann.rdapconformance.validator.workflow.rdap.RDAPValidator validator =
+                new org.icann.rdapconformance.validator.workflow.rdap.RDAPValidator(integrationContext);
+
+        validator.validate();
+
+        Set<RDAPValidationResult> allResults = integrationContext.getResults().getAll();
+        boolean has12100 = allResults.stream().anyMatch(r -> r.getCode() == -12100);
+
+        assertTrue(has12100, "RDAPValidator must emit -12100 for 404 + array body (RCT-475)");
     }
 
     /**


### PR DESCRIPTION
## Required Information

### PR Description (Include comprehensive description)

#### Summary of changes:
When a server returns HTTP 404 with an invalid JSON body (e.g. [] or
malformed JSON), the validate() method in RDAPHttpQuery was setting
isQuerySuccessful = false unconditionally, causing run() to return false
and exiting RDAPValidator before reaching validator.validate(). This
prevented the rdap_error.json SchemaValidator from emitting -12100.

Fix: only set isQuerySuccessful = false for non-404 responses when JSON
is invalid, allowing the 404 flow to continue through isErrorContent()
→ validator.validate() → -12100.

- RDAPHttpQuery.java: guard isQuerySuccessful = false with
  httpStatusCode != HTTP_NOT_FOUND check
#### Problem/feature addressed:
ErrorCode 12100 is not getting triggered for the condition met
#### Relevant screenshots/diagrams:

#### Links to relevant issues/tasks:
https://icann-jira.atlassian.net/browse/RCT-475
### Branch Name

- [x] Does the branch name follow the Branch Naming Convention?

#### If not, explain why:

### Code Changes

- [x] Are code changes adhering to coding standards and practices?

#### If not, explain why:

### Commit Messages

- [ ] Do commit messages follow [Conventional Commits guidelines](https://wecann.icann.org/docs/DOC-40501)?
- [x] Are they clear, concise, and informative using imperative language?

#### If not, explain why:

### Tests and Test Coverage

- [x] Are changes covered by appropriate tests?
- [ ] Were unit tests, integration tests, and end-to-end tests run?
- [ ] Was the test coverage maintained or improved? Please include before/after results.

#### If not, explain why:

### Bug Fixes and Tests

- [ ] For bug fixes, are there:
    - [x] Tests that reproduce the bug before the changes?
    - [ ] Tests that demonstrate the bug is resolved after the changes?

#### If not, explain why:

### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Documentation

- [ ] Are there updates to documentation that need to be made?
- [ ] Are they included or linked in the PR description?

#### If not, explain why:

### PR Size

- [x] Is the PR small and focused on one logical change?

#### If not, explain why:

---