### PR TITLE
fix/return-13002-error when localhost is activated

### DIFF
--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
@@ -493,10 +493,14 @@ public class RDAPHttpQuery implements RDAPQuery {
         boolean isValidStatusCode =
                 httpResponse != null && List.of(HTTP_OK, HTTP_NOT_FOUND).contains(httpResponse.statusCode());
 
-        if (!isValidStatusCode) {
-            String statusValue =
-                    httpResponse == null ? "no response available" : String.valueOf(httpResponse.statusCode());
-            queryContext.addError(-13002, statusValue, "The HTTP status code was neither 200 nor 404.");
+        if (httpResponse == null) {
+            // No response received (SSRF block, timeout, DNS failure, etc.)
+            // -13007 is already emitted by RDAPHttpRequest — do NOT duplicate with -13002
+            logger.debug("No HTTP response available, skipping status code validation");
+        } else if (!isValidStatusCode) {
+            // Got a response but status code is not 200 or 404
+            queryContext.addError(-13002, String.valueOf(httpResponse.statusCode()),
+                    "The HTTP status code was neither 200 nor 404.");
         }
 
         // Early termination for client errors (4xx) - these indicate issues with the request itself

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
@@ -494,8 +494,8 @@ public class RDAPHttpQuery implements RDAPQuery {
                 httpResponse != null && List.of(HTTP_OK, HTTP_NOT_FOUND).contains(httpResponse.statusCode());
 
         if (httpResponse == null) {
-            // No response received (SSRF block, timeout, DNS failure, etc.)
-            // -13007 is already emitted by RDAPHttpRequest — do NOT duplicate with -13002
+            // No response received (SSRF block, timeout, network error, etc.)
+            // Connection/DNS-level errors are emitted elsewhere (e.g., -13007/-13019); do NOT duplicate with -13002
             logger.debug("No HTTP response available, skipping status code validation");
         } else if (!isValidStatusCode) {
             // Got a response but status code is not 200 or 404

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQuery.java
@@ -489,16 +489,14 @@ public class RDAPHttpQuery implements RDAPQuery {
      * validation. All validation errors are automatically added to the results file.</p>
      */
     private void validate() {
+        // Handle the case where we need to add an error for non-200/404 status codes regardless of query success
         boolean isValidStatusCode =
                 httpResponse != null && List.of(HTTP_OK, HTTP_NOT_FOUND).contains(httpResponse.statusCode());
 
-        // Only emit -13002 when an HTTP response was actually received with a non-200/404 status code.
-        // When httpResponse is null the connection never completed (SSRF blocked, no IPv6 address,
-        // or network error) — "HTTP status code was neither 200 nor 404" is semantically incorrect
-        // in that case and would generate false positives for IPv4-only WireMock/QA endpoints.
-        if (!isValidStatusCode && httpResponse != null) {
-            queryContext.addError(-13002, String.valueOf(httpResponse.statusCode()),
-                    "The HTTP status code was neither 200 nor 404.");
+        if (!isValidStatusCode) {
+            String statusValue =
+                    httpResponse == null ? "no response available" : String.valueOf(httpResponse.statusCode());
+            queryContext.addError(-13002, statusValue, "The HTTP status code was neither 200 nor 404.");
         }
 
         // Early termination for client errors (4xx) - these indicate issues with the request itself

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpRequest.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpRequest.java
@@ -890,6 +890,9 @@ public class RDAPHttpRequest {
 
                 if (directlyBlocked || crossFamilyBlocked) {
                     logger.warn("Blocked connection to internal/private IP: {} (host: {})", resolvedIp, resolvedHost);
+                    if (canRecordError) {
+                        qctx.addError(ZERO, -13007, "no response available", "Failed to connect to server.");
+                    }
                     tracker.completeTrackingById(trackingId, ZERO, ConnectionStatus.UNKNOWN_HOST);
                     SimpleHttpResponse resp = new SimpleHttpResponse(trackingId, ZERO, EMPTY_STRING, originalUri, new Header[ZERO]);
                     resp.setConnectionStatusCode(ConnectionStatus.UNKNOWN_HOST);

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQueryTest.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/http/RDAPHttpQueryTest.java
@@ -1192,4 +1192,34 @@ public class RDAPHttpQueryTest extends HttpTestingUtils {
         }
     }
 
+    @Test
+    public void test_NoResponse_SsrfBlocked_DoesNotEmit13002() throws Exception {
+        RDAPValidatorResults results = queryContext.getResults();
+        results.clear();
+
+        URI uri = URI.create("http://10.0.0.1/domain/test.example");
+        doReturn(uri).when(config).getUri();
+
+        // Simulate what RDAPHttpRequest returns when SSRF blocks the connection:
+        // a SimpleHttpResponse with statusCode=0 and UNKNOWN_HOST
+        RDAPHttpRequest.SimpleHttpResponse blockedResponse = mock(RDAPHttpRequest.SimpleHttpResponse.class);
+        when(blockedResponse.statusCode()).thenReturn(0);
+        when(blockedResponse.body()).thenReturn("");
+        when(blockedResponse.uri()).thenReturn(uri);
+        when(blockedResponse.headers()).thenReturn(HttpHeaders.of(Map.of(), (k, v) -> true));
+        when(blockedResponse.getConnectionStatusCode()).thenReturn(ConnectionStatus.UNKNOWN_HOST);
+
+        try (MockedStatic<RDAPHttpRequest> mockedStatic = mockStatic(RDAPHttpRequest.class)) {
+            mockedStatic.when(() -> RDAPHttpRequest.makeRequest(
+                            any(QueryContext.class), eq(uri), anyInt(), eq("GET"), eq(true)))
+                    .thenReturn(blockedResponse);
+
+            rdapHttpQuery.run();
+
+            // -13002 must NOT be emitted when there is no HTTP response
+            assertThat(results.getAll())
+                    .as("SSRF-blocked (null response) must not emit -13002")
+                    .noneMatch(r -> r.getCode() == -13002);
+        }
+    }
 }

--- a/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/http/SsrfDualStackTest.java
+++ b/validator/src/test/java/org/icann/rdapconformance/validator/workflow/rdap/http/SsrfDualStackTest.java
@@ -156,6 +156,34 @@ public class SsrfDualStackTest {
                 .isEqualTo(ConnectionStatus.UNKNOWN_HOST);
     }
 
+    @Test
+    public void ssrf_IPv4Round_PrivateIPv4_IsBlocked_EmitsError() throws Exception {
+        URI uri = URI.create("http://" + TEST_HOST + ":" + wireMockServer.port() + REQUEST_PATH);
+        doReturn(uri).when(config).getUri();
+
+        RDAPValidatorResults results = new RDAPValidatorResultsImpl();
+        RDAPDatasetServiceMock datasetService = new RDAPDatasetServiceMock();
+        datasetService.download(true);
+
+        QueryContext qctx = QueryContext.forTesting("", results, config, datasetService);
+        qctx.setSsrfProtectionEnabled(true);
+        qctx.setStackToV4();
+
+        DNSCacheResolver fakeResolver = buildFakeDnsResolver(
+                TEST_HOST,
+                InetAddress.getByName(PRIVATE_IPv4),
+                null
+        );
+        injectDnsResolver(qctx, fakeResolver);
+
+        // canRecordError = true — should emit -13007
+        RDAPHttpRequest.makeRequest(qctx, uri, 5, "GET", false, true);
+
+        assertThat(results.getAll())
+                .as("SSRF block must emit -13007")
+                .anyMatch(r -> r.getCode() == -13007);
+    }
+
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Required Information

### PR Description (Include comprehensive description)

#### Summary of changes:
fix(ssrf): emit -13007 when SSRF blocks connection instead of misusing -13002

- Add qctx.addError(-13007) in the SSRF block path of RDAPHttpRequest
  so that blocked connections produce a proper "Failed to connect to server"
  error instead of relying on the -13002 fallback in validate()

- Restrict -13002 in RDAPHttpQuery.validate() to only fire when an actual
  HTTP response was received with a non-200/404 status code; null responses
  (SSRF block, timeout, DNS failure) no longer trigger -13002 incorrectly

- Add SsrfDualStackTest#ssrf_IPv4Round_PrivateIPv4_IsBlocked_EmitsError
  to verify that a blocked IPv4 connection with canRecordError=true
  produces a -13007 result
#### Problem/feature addressed:
When we use locacalhost in ssrfhost for the case where we run in qa ennvironment - it used to trigger errorCode 13002
With the new build no errorCode
#### Relevant screenshots/diagrams:

#### Links to relevant issues/tasks:
https://icann-jira.atlassian.net/browse/RCT-526
### Branch Name

- [x] Does the branch name follow the Branch Naming Convention?

#### If not, explain why:

### Code Changes

- [x] Are code changes adhering to coding standards and practices?

#### If not, explain why:

### Commit Messages

- [ ] Do commit messages follow [Conventional Commits guidelines](https://wecann.icann.org/docs/DOC-40501)?
- [x] Are they clear, concise, and informative using imperative language?

#### If not, explain why:

### Tests and Test Coverage

- [x] Are changes covered by appropriate tests?
- [ ] Were unit tests, integration tests, and end-to-end tests run?
- [ ] Was the test coverage maintained or improved? Please include before/after results.

#### If not, explain why:

### Bug Fixes and Tests

- [ ] For bug fixes, are there:
    - [x] Tests that reproduce the bug before the changes?
    - [ ] Tests that demonstrate the bug is resolved after the changes?

#### If not, explain why:

### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Documentation

- [ ] Are there updates to documentation that need to be made?
- [x] Are they included or linked in the PR description?

#### If not, explain why:

### PR Size

- [x] Is the PR small and focused on one logical change?

#### If not, explain why:

---