### PR TITLE
fix: Add validations from TigValidation1Dot12Dot1 to RDAPValidator

### DIFF
--- a/tool/src/test/java/org/icann/rdapconformance/tool/RdapWebValidatorTest.java
+++ b/tool/src/test/java/org/icann/rdapconformance/tool/RdapWebValidatorTest.java
@@ -60,15 +60,11 @@ public class RdapWebValidatorTest {
 
     @Test
     public void testValidateReturnsResults() {
-        // This test will fail in network-isolated environments
-        // but demonstrates the interface works
-        RdapWebValidator validator = new RdapWebValidator("https://rdap.arin.net/registry/entity/GOGL");
-
-        // Should not throw exceptions and should return results object
+        URI testUri = URI.create("https://rdap.arin.net/registry/entity/GOGL");
+        // Use local datasets to avoid CI network flakiness
+        RdapWebValidator validator = new RdapWebValidator(testUri, false, false, true);
         RDAPValidatorResults results = validator.validate();
-
         assertNotNull(results);
-        // Results may contain validation errors, but the interface should work
     }
 
     @Test

--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidator.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidator.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain.entities.ResponseValidation2Dot7Dot5Dot3_2024;
 import org.icann.rdapconformance.validator.workflow.profile.rdap_response.entity.ResponseValidationTechHandle_2024;
 import org.icann.rdapconformance.validator.workflow.profile.tig_section.general.*;
+import org.icann.rdapconformance.validator.workflow.profile.tig_section.registrar.TigValidation1Dot12Dot1;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -200,6 +201,7 @@ public class RDAPValidator implements ValidatorWorkflow {
         List<ProfileValidation> validations = new ArrayList<>();
 
         // All validations in original order
+        validations.add(new TigValidation1Dot12Dot1(queryContext));
         validations.add(new TigValidation3Dot2(queryContext));
         validations.add(new TigValidation4Dot1(queryContext));
         validations.add(new TigValidation7Dot1And7Dot2(queryContext));


### PR DESCRIPTION
## Required Information

### PR Description (Include comprehensive description)

#### Summary of changes:

#### Problem/feature addressed:
The -26103 validation (TigValidation1Dot12Dot1) is implemented and has unit tests, but it is not wired into the runtime validation list in RDAPValidator.get2024ProfileValidations(). As a result, this check never executes in real tool runs — that's why tigSection_1_12_1_Validation is absent from both groupOK and groupErrorWarning in the result file, and why -26103 never fires regardless of the payload. This is a tool bug that needs a code fix (add validations.add(new TigValidation1Dot12Dot1(queryContext)); to RDAPValidator.java). The -47701 you're seeing is a different but related check (ResponseValidation2Dot4Dot6_2024) that IS registered and working.
#### Relevant screenshots/diagrams:

#### Links to relevant issues/tasks:
https://icann-jira.atlassian.net/browse/RCT-483
### Branch Name

- [x] Does the branch name follow the Branch Naming Convention?

#### If not, explain why:

### Code Changes

- [x] Are code changes adhering to coding standards and practices?

#### If not, explain why:

### Commit Messages

- [ ] Do commit messages follow [Conventional Commits guidelines](https://wecann.icann.org/docs/DOC-40501)?
- [x] Are they clear, concise, and informative using imperative language?

#### If not, explain why:

### Tests and Test Coverage

- [x] Are changes covered by appropriate tests?
- [ ] Were unit tests, integration tests, and end-to-end tests run?
- [ ] Was the test coverage maintained or improved? Please include before/after results.

#### If not, explain why:

### Bug Fixes and Tests

- [ ] For bug fixes, are there:
    - [ ] Tests that reproduce the bug before the changes?
    - [ ] Tests that demonstrate the bug is resolved after the changes?

#### If not, explain why:

### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Documentation

- [ ] Are there updates to documentation that need to be made?
- [x] Are they included or linked in the PR description?

#### If not, explain why:

### PR Size

- [x] Is the PR small and focused on one logical change?

#### If not, explain why:

---