### PR TITLE
bug/RCT-547-error-code-52105-incorrectly

### DIFF
--- a/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidator.java
+++ b/validator/src/main/java/org/icann/rdapconformance/validator/workflow/rdap/RDAPValidator.java
@@ -35,7 +35,6 @@ import org.icann.rdapconformance.validator.workflow.DomainCaseFoldingValidation;
 import org.icann.rdapconformance.validator.workflow.ValidatorWorkflow;
 import org.icann.rdapconformance.validator.workflow.profile.ProfileValidation;
 import org.icann.rdapconformance.validator.workflow.profile.RDAPProfile;
-import org.icann.rdapconformance.validator.workflow.profile.rdap_response.domain.entities.ResponseValidation2Dot7Dot1DotXAndRelated6;
 import org.icann.rdapconformance.validator.workflow.profile.rdap_response.miscellaneous.ResponseValidationLastUpdateEvent;
 import org.icann.rdapconformance.validator.workflow.profile.rdap_response.nameserver.ResponseNameserverStatusValidation;
 import org.icann.rdapconformance.validator.workflow.profile.rdap_response.nameserver.ResponseValidation4Dot1Handle;
@@ -237,7 +236,14 @@ public class RDAPValidator implements ValidatorWorkflow {
         validations.add(new ResponseValidation4Dot1Handle(queryContext));
         validations.add(new ResponseValidation4Dot1Query(queryContext));
         validations.add(new ResponseValidation4Dot3(queryContext));
-        validations.add(new ResponseValidation2Dot7Dot1DotXAndRelated6(queryContext));
+
+        // NOTE: ResponseValidation2Dot7Dot1DotXAndRelated6 (-52105, missing "cc"
+        // parameter on the registrant's jCard "adr") is intentionally NOT included
+        // in the Feb 2024 profile validation set. That check belongs to the Feb 2019
+        // RDAP Response Profile (section 2.7.3.1 of RDAP_Response_Profile_2_1) and
+        // is superseded in the 2024 profile by -62101 (ResponseValidation1Dot2_4_2024),
+        // which enforces the same requirement for all jCards. Keeping both under 2024
+        // produces duplicate findings for the same underlying issue.
 
         // 2024 specific validations
         validations.add(new TigValidation1Dot3_2024(queryContext));


### PR DESCRIPTION
## Required Information

### PR Description (Include comprehensive description)

#### Summary of changes:
change: Exclude ResponseValidation2Dot7DotXAndRelated6 from Feb 2024 profile validation set to avoid duplicate findings

#### Problem/feature addressed:
RDAP: Error Code -52105 is incorrectly reported while testing Error Code -62101 under RDAP Response Profile 2024
#### Relevant screenshots/diagrams:

#### Links to relevant issues/tasks:
https://icann-jira.atlassian.net/browse/RCT-547
### Branch Name

- [x] Does the branch name follow the Branch Naming Convention?

#### If not, explain why:

### Code Changes

- [x] Are code changes adhering to coding standards and practices?

#### If not, explain why:

### Commit Messages

- [ ] Do commit messages follow [Conventional Commits guidelines](https://wecann.icann.org/docs/DOC-40501)?
- [x] Are they clear, concise, and informative using imperative language?

#### If not, explain why:

### Tests and Test Coverage

- [x] Are changes covered by appropriate tests?
- [ ] Were unit tests, integration tests, and end-to-end tests run?
- [ ] Was the test coverage maintained or improved? Please include before/after results.

#### If not, explain why:

### Bug Fixes and Tests

- [ ] For bug fixes, are there:
    - [x] Tests that reproduce the bug before the changes?
    - [ ] Tests that demonstrate the bug is resolved after the changes?

#### If not, explain why:

### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Documentation

- [ ] Are there updates to documentation that need to be made?
- [x] Are they included or linked in the PR description?

#### If not, explain why:

### PR Size

- [x] Is the PR small and focused on one logical change?

#### If not, explain why:

---